### PR TITLE
Make mdmost the thing that opens a Markdown file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,9 @@ jobs:
           cp "$BINARY" staging/mdmost/
           cp man/mdmost.1 staging/mdmost/man/
           cp README.md LICENSE staging/mdmost/
+          # The Homebrew formula installs integrations/ out of this tarball, so it has
+          # to be in here; `brew install` never sees the repository.
+          cp -R integrations staging/mdmost/
           tar -czvf "dist/${ARCHIVE}" -C staging mdmost
         shell: bash
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,21 @@
 - Prebuilt binaries for Linux (static musl, x86_64 and aarch64), macOS (Intel and
   Apple silicon) and Windows, with `.deb` and `.rpm` packages, a Homebrew tap in this
   repository, and publication to crates.io.
+- Configuration fragments in `integrations/` that make **mdmost** the thing a click
+  opens a Markdown file with: a WezTerm Lua module, a kitty `open-actions.conf`
+  stanza, and an XDG desktop entry. The terminal fragments hook the terminal's own
+  link handling rather than the operating system's file association, so they need
+  nothing registered and work the same on Linux and macOS — which is the only route
+  open on macOS, where Launch Services binds a file type to an application bundle
+  and a terminal program has none. The `.deb` and the `.rpm` install the desktop
+  entry to `/usr/share/applications`, so a system-wide install offers **mdmost** for a
+  Markdown file to every user on the machine — declaring what it can open, while
+  leaving which application wins to `xdg-mime`. The terminal fragments cannot be
+  installed that way, because neither WezTerm nor kitty has a drop-in directory and
+  each reads one file owned by the user, so those ship as examples in
+  `/usr/share/doc/mdmost/examples/`. Homebrew keeps all three under `pkgshare`: its
+  prefix is not on a desktop session's `XDG_DATA_DIRS`, so a desktop entry installed
+  there would never be found.
 
 ### Changed
 
@@ -40,7 +55,10 @@
   source for every key, option and config field; `man/mdmost.1` is generated from
   it by `make man` and is no longer kept in git; the README is a 30-second pitch
   that links to the rest. A new terminal-setup section says which Unicode blocks
-  your font has to cover, and a test keeps that list matching the renderer.
+  your font has to cover, and a test keeps that list matching the renderer. A
+  **DEFAULT MARKDOWN VIEWER** section covers the two separate mechanisms that can
+  hand a file to **mdmost** — the desktop's file association and the terminal's own
+  link handling — with the configuration for each.
 - The licence file is named `LICENSE` rather than `LICENSE-MIT`, which is the name
   forges, packagers and licence scanners look for. Both packages now install it to
   `/usr/share/doc/mdmost/LICENSE`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,11 +114,26 @@ is a pure function of the document, width, theme and options, so a resize \
 reflows everything. A single static binary."""
 section = "utils"
 priority = "optional"
+# The desktop entry is installed for real, not as an example: this package is a
+# system-wide install, so every user on the machine should be offered mdmost for a
+# Markdown file. It only declares the capability -- no mimeapps.list is shipped, so
+# the default stays each user's own choice. desktop-file-utils carries a dpkg trigger
+# on /usr/share/applications, so update-desktop-database runs without a maintainer
+# script of ours.
+#
+# The terminal fragments cannot be installed the same way. WezTerm and kitty each
+# read one file owned by the user, and neither has a drop-in directory, so anywhere
+# a package put them would be somewhere nothing reads. They go in as examples, at the
+# path Debian Policy 12.6 names for them.
 assets = [
     ["target/release/mdmost", "usr/bin/", "755"],
     ["man/mdmost.1", "usr/share/man/man1/", "644"],
+    ["integrations/xdg/mdmost.desktop", "usr/share/applications/", "644"],
     ["README.md", "usr/share/doc/mdmost/README.md", "644"],
     ["LICENSE", "usr/share/doc/mdmost/LICENSE", "644"],
+    ["integrations/README.md", "usr/share/doc/mdmost/examples/README.md", "644"],
+    ["integrations/wezterm/md-open.lua", "usr/share/doc/mdmost/examples/wezterm/", "644"],
+    ["integrations/kitty/open-actions.conf", "usr/share/doc/mdmost/examples/kitty/", "644"],
 ]
 
 [package.metadata.generate-rpm]
@@ -130,6 +145,13 @@ auto-req = "no"
 assets = [
     { source = "target/release/mdmost", dest = "/usr/bin/mdmost", mode = "755" },
     { source = "man/mdmost.1", dest = "/usr/share/man/man1/mdmost.1", mode = "644", doc = true },
+    # Installed for real rather than as an example, and not doc: see the note above
+    # the [package.metadata.deb] assets. desktop-file-utils carries an RPM file
+    # trigger on this directory, so no scriptlet of ours is needed either.
+    { source = "integrations/xdg/mdmost.desktop", dest = "/usr/share/applications/mdmost.desktop", mode = "644" },
     { source = "README.md", dest = "/usr/share/doc/mdmost/README.md", mode = "644", doc = true },
     { source = "LICENSE", dest = "/usr/share/doc/mdmost/LICENSE", mode = "644", doc = true },
+    { source = "integrations/README.md", dest = "/usr/share/doc/mdmost/examples/README.md", mode = "644", doc = true },
+    { source = "integrations/wezterm/md-open.lua", dest = "/usr/share/doc/mdmost/examples/wezterm/md-open.lua", mode = "644", doc = true },
+    { source = "integrations/kitty/open-actions.conf", dest = "/usr/share/doc/mdmost/examples/kitty/open-actions.conf", mode = "644", doc = true },
 ]

--- a/Formula/mdmost.rb
+++ b/Formula/mdmost.rb
@@ -37,6 +37,18 @@ class Mdmost < Formula
   def install
     bin.install "mdmost"
     man1.install "man/mdmost.1"
+    # Terminal configuration fragments, as examples. Nothing loads them from here:
+    # WezTerm and kitty each read one file owned by the user, so these are copied by
+    # hand. See integrations/README.md, and mdmost(1) DEFAULT MARKDOWN VIEWER.
+    pkgshare.install "integrations"
+  end
+
+  def caveats
+    <<~EOS
+      To open Markdown files with mdmost by clicking a file:// link in your
+      terminal, copy the fragment for it out of:
+        #{opt_pkgshare}/integrations
+    EOS
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 A full-screen terminal pager for one Markdown document
 
-* resize the terminal and everyting will reflow
-* mermaind diagrams -> rendered
-* hilight with the mouse -> markdown source copied
-* table too wide -> side scrolling just the table
+* resize the terminal and everything reflows
+* mermaid diagrams -> rendered
+* highlight with the mouse -> Markdown source copied
+* table too wide -> side-scroll just the table
 
 ![less on the left, mdmost on the right, on the same file](https://raw.githubusercontent.com/oetiker/mdmost/main/docs/demo/mdmost.webp)
 
@@ -45,13 +45,13 @@ sudo install -Dm644 mdmost/man/mdmost.1 /usr/local/share/man/man1/mdmost.1
 ```
 
 **Rust** — `cargo install mdmost`, or `cargo build --release` from a checkout. Neither
-route gives you a man page: `cargo install` does not install them at all, and the page
-is generated rather than shipped. Run `make man` in a checkout if you want one (it
-needs pandoc). Rust 2024 edition; no system dependencies beyond a terminal that speaks
-ANSI truecolour. Pure Rust all the way down — the build needs no C compiler, which is
-why the regex engine behind the highlighter is `fancy-regex` rather than oniguruma.
+route installs a man page: `cargo install` does not handle man pages at all, and the page
+is generated rather than shipped. Run `make man` in a checkout to build one; it needs
+pandoc. Rust 2024 edition, and no system dependencies beyond a terminal that speaks ANSI
+truecolour. The build needs no C compiler, which is why the regex engine behind the
+highlighter is `fancy-regex` rather than oniguruma.
 
-Two honest caveats. The **macOS** tarball binaries are neither signed nor notarised, so
+Two caveats. The **macOS** tarball binaries are neither signed nor notarised, so
 Gatekeeper will quarantine them; `brew install` is the path of least resistance. The
 **Windows** build compiles and is checked on every push but has never been exercised in
 anger: expect the mouse, the clipboard and font detection to be less well behaved there
@@ -68,11 +68,11 @@ mdmost --mouse README.md      # wheel, drag-to-copy, clickable links
 mdmost --render-once notes.md # print one frame and exit
 ```
 
-Two things make the pipe cases work. When the input is a pipe the keyboard is read from
-`/dev/tty`, so `cat x.md | mdmost` is still interactive; and when *stdout* is not a
-terminal `--render-once` is implied, so `mdmost x.md | cat` produces plain text instead
-of escape soup. That is what makes `mdmost --render-once --width 80 doc.md` usable for
-scripting and snapshotting.
+Two rules make the pipe cases work. When the input is a pipe, the keyboard is read from
+`/dev/tty`, so `cat x.md | mdmost` stays interactive. When *stdout* is not a terminal,
+`--render-once` is implied, so `mdmost x.md | cat` produces plain text instead of escape
+sequences. `mdmost --render-once --width 80 doc.md` is therefore usable for scripting and
+snapshotting.
 
 Every flag is in the
 [manual](https://github.com/oetiker/mdmost/blob/main/docs/manual.md#options), or in
@@ -80,54 +80,50 @@ Every flag is in the
 
 ## What makes it different
 
-**Resizing is the point, not a feature.** No layout decision is taken at parse time, so
-a resize does not patch what is on screen — it renders the document again at the new
-width. A table renegotiates its columns, a diagram re-lays its node boxes, and prose
-re-wraps.
+**Resizing re-renders.** No layout decision is taken at parse time, so a resize does not
+patch what is on screen: it renders the document again at the new width. A table
+renegotiates its columns, a diagram re-lays its node boxes, and prose re-wraps.
 
-**Wide things scroll sideways instead of being mangled.** Some content will not fold at
-any width: a five-column table, a diagram that wants 188 columns, a long line of code.
-It keeps its shape and you reach the rest with `left` and `right` — and **it scrolls on
-its own**, while the prose around it stays exactly where it was. A cut line is marked at
-the edge, and a box's rules still close with the corner they belong to, so a frame that
-continues off-screen still reads as a frame.
+**Wide content scrolls sideways.** Some content will not fold at any width: a
+five-column table, a diagram that wants 188 columns, a long line of code. It keeps its
+shape, and `left` and `right` reach the rest. It scrolls on its own, while the prose
+around it stays where it was. A cut line is marked at the edge, and a box's rules still
+close with the corner they belong to.
 
-**The mouse works properly.** With `--mouse` the wheel scrolls, the scrollbar drags,
-contents entries jump, links light up under the pointer with their target in the status
-bar, and code frames and tables grow a `[copy]` button. It is off by default because
-capturing the mouse takes away the terminal's own drag-select, and that is your call to
-make rather than mine.
+**The mouse works.** With `--mouse` the wheel scrolls, the scrollbar drags, contents
+entries jump, links light up under the pointer with their target in the status bar, and
+code frames and tables grow a `[copy]` button. It is off by default, because capturing
+the mouse takes away the terminal's own drag-select.
 
-**A selection copies the source, not the screen.** Drag over a rendered heading and you
-get `# Wide diagram` on the clipboard; over a bold word, `**bold**`; over a link,
-`[text](url)`. A drag that reflowed across several rows copies the source's own line
-breaks. The `[copy]` buttons take a whole block: code exactly as written, a table as
-tab-separated cells a spreadsheet will split into columns.
+**A selection copies the source, not the screen.** Drag over a rendered heading and
+`# Wide diagram` lands on the clipboard; over a bold word, `**bold**`; over a link,
+`[text](url)`. A drag across reflowed rows copies the source's own line breaks. The
+`[copy]` buttons take a whole block: code exactly as written, a table as tab-separated
+cells a spreadsheet will split into columns.
 
-**Links, anchors and footnotes are live.** Clicking an `http` link opens it; a `#heading`
-reference scrolls there. No mouse is needed: `f` walks a keyboard cursor from one control
-to the next and `enter` follows it, with the full URL in the status bar first. A footnote
-marker opens the note in a box beside it without moving the page.
+**Links, anchors and footnotes are live.** Clicking an `http` link opens it, and a
+`#heading` reference scrolls there. No mouse is needed: `f` walks a keyboard cursor from
+one control to the next, `enter` follows it, and the full URL is in the status bar first.
+A footnote marker opens the note in a box beside it without moving the page.
 
 **Mermaid becomes box art.** All seven families are drawn as Unicode rather than dumped
-as source, and anything outside the supported subset degrades to a highlighted code block
-with a caption saying why — a diagram never takes the document down with it.
-
+as source. Anything outside the supported subset degrades to a highlighted code block
+with a caption giving the reason.
 
 ## What it is not
 
-The scope is deliberately narrow, and these are decisions rather than gaps:
+The scope is narrow on purpose:
 
 - **Not an editor.** The document is read-only.
 - **No HTML.** Raw HTML in the source is skipped rather than rendered or shown.
-- **No images.** An image becomes a captioned placeholder with its alt text and
-  target — no sixel, no kitty protocol (yet).
+- **No images.** An image becomes a captioned placeholder with its alt text and target.
+  There is no sixel and no kitty protocol yet.
 
 ## Terminal setup
 
 `mdmost` draws box-drawing, block and geometric characters. If your terminal font does
 not cover them it falls back to one that does, and a fallback with a different advance
-width makes a line of box characters a different width from the text around it — so the
+width makes a line of box characters a different width from the text around it, so the
 frames shear. Nothing inside the pager can correct that.
 
 The [manual's terminal setup
@@ -138,7 +134,7 @@ rather than assumed, and `--no-icons` turns them off at the same display width.
 
 ## Configuration
 
-TOML, at `~/.config/mdmost/config.toml`. A broken file never stops the program from
+TOML, at `~/.config/mdmost/config.toml`. A broken file does not stop the program from
 starting: the problem is reported and the rest of the file still applies.
 
 ```toml
@@ -151,15 +147,15 @@ title_banner = false     # true sets a lone `#` title as a FIGlet banner
 ```
 
 `S` writes the settings you changed back to that file, keeping your comments and
-ordering. The full schema — every key, `[toc]`, `[keys]` and custom `[themes.*]` — is in
-the
+ordering. The full schema, with every key, `[toc]`, `[keys]` and custom `[themes.*]`, is
+in the
 [manual](https://github.com/oetiker/mdmost/blob/main/docs/manual.md#configuration).
 
 ## Keys
 
 | Keys | Action |
 |---|---|
-| `q` | Quit — `esc` never quits |
+| `q` | Quit; `esc` does not quit |
 | `h`, `f1` | Show or hide the help overlay |
 | `j`, `k` | Scroll one line |
 | `space`, `b` | Scroll one screen |
@@ -172,8 +168,8 @@ the
 
 All 45 bindings, and how to remap them, are in `man mdmost` or the
 [manual](https://github.com/oetiker/mdmost/blob/main/docs/manual.md#keys). The in-app
-help overlay is generated from the same live binding table, so it never drifts from what
-you have actually bound.
+help overlay is generated from the same live binding table, so it shows the bindings in
+effect rather than the defaults.
 
 ## Development
 
@@ -194,7 +190,7 @@ MIT.
 The syntax definitions compiled into the binary are third-party work, curated by the
 [`bat` project](https://github.com/sharkdp/bat) and packaged by
 [`two-face`](https://codeberg.org/CosmicHarper/two-face). Most are under Sublime's
-permissive notice or the Unlicense; the MIT, BSD and Apache-2.0 ones among them require
-their notices to be reproduced in binary distributions, and `mdmost --licenses` is where
-they are — inside the binary, which is the artefact people actually receive. The TOML and
-Dockerfile definitions in `assets/syntaxes/` are `mdmost`'s own and MIT like the rest.
+permissive notice or the Unlicense. The MIT, BSD and Apache-2.0 ones among them require
+their notices to be reproduced in binary distributions, and `mdmost --licenses` prints
+them. The TOML and Dockerfile definitions in `assets/syntaxes/` are `mdmost`'s own, MIT
+like the rest.

--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -154,6 +154,31 @@ What is deliberately not automated, and why, is in
 `docs/superpowers/specs/2026-08-09-publishing-design.md` §1 — there is no apt/yum
 repository, no Pages site, no container image and no macOS notarisation.
 
+## Why the defaults are what they are
+
+The manual states these defaults without arguing for them, because a man page is a
+reference. The arguments are here, so that a later change is a decision rather than an
+accident:
+
+- **The prose cap is 72 columns.** A line that runs the full width of a wide terminal is
+  hard to come back from: the eye loses the start of the next one. Seventy-two is inside
+  the readable band rather than at the top of it, which is why the cap still bites on an
+  80-column terminal.
+- **`title_banner` is off.** FIGlet art in place of someone else's title is a decoration,
+  and a default is the wrong place to hold that opinion.
+- **Icon detection breaks the tie towards plain.** Guessing wrong towards plain costs a
+  little elegance; guessing wrong towards icons fills the screen with replacement boxes.
+  See also `render::glyph` and the note on `unicode-width` above.
+- **List bullets and task boxes are ASCII.** Lists turn up in nearly every document, so
+  their markers are the glyphs that can least afford to be invisible, and most of them
+  are the literal Markdown the author typed.
+- **`pie` is drawn as sorted bars.** A circle in character cells reads badly.
+- **`[copy]` buttons appear only when the mouse was captured.** A control nobody can
+  press is worse than none.
+- **Colours never come from the syntax definitions.** Each scope maps to a semantic slot
+  and the slot is filled from the active theme, so code sits inside the palette instead
+  of fighting it.
+
 ## Regenerating the man page
 
 `docs/manual.md` is the source. `man/mdmost.1` is generated from it and **is not in

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -3,7 +3,7 @@ title: MDMOST
 section: 1
 header: mdmost manual
 footer: mdmost
-date: 2026-08-13
+date: 2026-08-17
 ---
 
 # NAME
@@ -577,6 +577,176 @@ Plain and icon glyphs occupy **the same display width**, so nothing shifts and
 nothing reflows either way --- the difference is what the markers look like,
 never where anything sits, and no feature is lost. To decide for yourself rather
 than let it detect, see **CONFIGURATION**.
+
+# DEFAULT MARKDOWN VIEWER
+
+Two unrelated mechanisms can hand a Markdown file to **mdmost**. Which one you
+want depends on where you click.
+
+- **The desktop's file association** — What a file manager consults when you
+  double-click *notes.md*. It is a registry belonging to the operating system, and
+  on Linux it is an open standard that any program may register with.
+
+- **The terminal's own link handling** — What runs when you click a `file://` link
+  in terminal output. The terminal settles this itself, before the operating system
+  is ever consulted, so it is configured once per terminal and behaves the same on
+  Linux and on macOS.
+
+On macOS only the second is open to **mdmost**. Launch Services binds a file type
+to an *application bundle*, and a program that draws in a terminal has no bundle to
+register. That is why the macOS instructions below are per terminal rather than
+system-wide, and it is not a gap that a package can close.
+
+Neither mechanism is how you make **mdmost** the pager that other command-line
+programs reach for; for that see `PAGER` under **ENVIRONMENT**.
+
+## The desktop file association on Linux
+
+Markdown's registered media type is `text/markdown`. Describe **mdmost** to the
+desktop in *~/.local/share/applications/mdmost.desktop*:
+
+```ini
+[Desktop Entry]
+Type=Application
+Name=mdmost
+Comment=Read a Markdown document in the terminal
+Exec=mdmost %f
+Terminal=true
+MimeType=text/markdown;
+Categories=Utility;TextEditor;ConsoleOnly;
+```
+
+Then refresh the lookup cache and claim the type:
+
+```sh
+update-desktop-database ~/.local/share/applications
+xdg-mime default mdmost.desktop text/markdown
+```
+
+`xdg-mime query default text/markdown` now answers `mdmost.desktop`.
+
+Three things about that file are worth knowing:
+
+- **`Terminal=true` is the weak part** — **mdmost** needs a terminal, so the desktop
+  has to find a terminal emulator to put it in. Which one it settles on, and whether
+  it manages to settle on one at all, has changed more than once. A double-click
+  that appears to do nothing is this, and the per-terminal setup below is the more
+  dependable answer.
+
+- **`text/x-markdown` needs no line of its own** — The shared-mime-info database
+  declares it an alias of `text/markdown`, so it resolves through it.
+
+- **`Exec` is resolved on `PATH`** — A bare `mdmost` is right here, and it is what
+  a packaged copy of this file has to say.
+
+The `.deb` and the `.rpm` install that entry to */usr/share/applications* already, so
+on those there is nothing to write: **mdmost** is offered for a Markdown file to every
+user on the machine, and only the `xdg-mime` line above is left to you. Write the file
+yourself when you installed from Homebrew or the tarball, or when you want it for one
+account rather than all of them.
+
+What no package does, and none should, is decide which application wins. Declaring
+that **mdmost** *can* open Markdown is a package's business; setting the default is
+the user's. The freedesktop specification reserves a system-wide *mimeapps.list* for
+the desktop environment, so a package that shipped one would be taking the
+association away from every editor on the machine.
+
+## Clicking a file:// link in the terminal
+
+A terminal turns `file:///path/to/notes.md` in its output into a link and hands it
+to the operating system's opener when clicked. The terminals below can be told to
+run something else instead, which keeps the whole business inside the terminal:
+nothing to register, and the same configuration on both platforms.
+
+Two points apply to all of them:
+
+- **Name mdmost by absolute path** — These terminals execute the program directly
+  rather than through a shell, so it is looked up on the terminal's own `PATH`, and a
+  terminal launched from the macOS Dock inherits a bare `PATH` with no Homebrew
+  prefix in it. Use the output of `command -v mdmost`.
+
+- **A link stops at whitespace** — The usual link patterns match runs of non-space
+  characters, so a path holding a literal space is only recognised as far as the
+  space. Percent-encode it as `%20`.
+
+### WezTerm
+
+WezTerm emits an `open-uri` event before it hands a link to the operating system,
+and a handler returning `false` suppresses that hand-off. In
+*~/.config/wezterm/wezterm.lua*:
+
+```lua
+local wezterm = require 'wezterm'
+
+local MDMOST = '/opt/homebrew/bin/mdmost'
+local MARKDOWN = {
+  md = true, markdown = true, mkd = true, mdown = true,
+}
+
+wezterm.on('open-uri', function(window, pane, uri)
+  -- Split host from path, then drop any query or fragment. A
+  -- '#' that belongs to the filename arrives percent-encoded,
+  -- so a literal one here is a delimiter.
+  local host, path = uri:match '^file://([^/]*)(/[^?#]*)'
+  if not path or (host ~= '' and host ~= 'localhost') then
+    return
+  end
+  path = path:gsub('%%(%x%x)', function(hex)
+    return string.char(tonumber(hex, 16))
+  end)
+  local ext = path:match '%.(%a+)$'
+  if not ext or not MARKDOWN[ext:lower()] then
+    return
+  end
+  local dir = path:match '^(.*)/[^/]*$'
+  if dir == nil or dir == '' then
+    dir = '/'
+  end
+  window:perform_action(
+    wezterm.action.SpawnCommandInNewWindow {
+      args = { MDMOST, path },
+      cwd = dir,
+    },
+    pane
+  )
+  return false
+end)
+```
+
+Returning nothing for everything else is what keeps `https` going to the browser
+and a remote host's `file://` out of a pager that has no such file to open. Do not
+reach for `wezterm.glob` to locate the binary: it is an async function, and calling
+it from a required module raises *attempt to yield across a C-call boundary*, which
+looks exactly like the binary not being installed.
+
+### Kitty
+
+Kitty reads *~/.config/kitty/open-actions.conf*, at that same path on Linux and on
+macOS. A stanza is match lines followed by action lines:
+
+```
+protocol file
+ext md,markdown,mkd,mdown
+action launch --type=os-window /opt/homebrew/bin/mdmost ${FILE_PATH}
+```
+
+`${FILE_PATH}` arrives decoded and unquoted, so there is nothing left to unescape.
+Add `--title ${FILE}` to name the window after the document, and drop
+`--type=os-window` for a new tab in the window you clicked in instead.
+
+### iTerm2
+
+iTerm2 has no per-scheme hook. What it has is Semantic History, under **Settings
+-> Profiles -> Advanced**: set it to **Run command...**, where `\1` stands for the
+path. Two things make it the coarser instrument. It fires on a Cmd-click over a
+filename rather than over a `file://` link, and it fires for every file rather than
+for Markdown alone --- so the command has to be a small script of your own that
+looks at the extension and hands anything else to an editor.
+
+### Terminal.app
+
+There is nothing to configure. Terminal.app passes every link it recognises to
+Launch Services and offers no way to intervene.
 
 # ENVIRONMENT
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -16,65 +16,61 @@ mdmost - full-screen terminal pager for a single Markdown document
 
 # DESCRIPTION
 
-**mdmost** parses a Markdown document once and draws it as styled Unicode: tables
-get real borders and negotiated column widths, fenced code is syntax-highlighted,
-and Mermaid diagrams are laid out as box art rather than shown as source.
+**mdmost** renders one Markdown document in the terminal. Tables get borders and
+negotiated column widths, fenced code is syntax-highlighted, and Mermaid diagrams
+are drawn as box art instead of shown as source.
 
-Rendering is a pure function of the document, the width, the theme and the
-options. No layout decision is taken at parse time, so resizing the terminal
-discards the canvas and renders again rather than patching what is on screen.
-That is why everything reflows, and why the same table is drawn dense in a wide
-terminal and spaced in a narrow one.
+Layout follows from the document, the terminal width, the theme and the options.
+A resize renders the document again rather than patching the screen, so
+everything reflows and the same table is drawn dense in a wide terminal and
+spaced in a narrow one.
 
-With no *FILE*, the document is read from standard input; the keyboard is then
-read from */dev/tty*, so `cat notes.md | mdmost` stays interactive. When standard
+With no *FILE*, the document is read from standard input and the keyboard is read
+from */dev/tty*, so `cat notes.md | mdmost` stays interactive. When standard
 output is not a terminal, `--render-once` is implied, so `mdmost doc.md | cat`
-produces plain text rather than escape sequences.
+writes plain text rather than escape sequences.
 
 # OPTIONS
 
-- **`--render-once`** — Render one frame to standard output and exit. Needs no terminal.
-  Truecolour goes to a terminal and plain text goes anywhere else, which is what makes
-  it usable for scripting and snapshotting.
+- **`--render-once`** — Render one frame to standard output and exit. No terminal is
+  needed. The output is truecolour to a terminal and plain text anywhere else.
 
-- **`--width N`** — Render the whole document at this width instead of the terminal's.
+- **`--width N`** — Render the whole document at width *N* instead of the terminal's.
 
-- **`--body-width N`** — Cap the prose body at N columns and centre it; `0` for no cap.
+- **`--body-width N`** — Cap the prose body at *N* columns and centre it; `0` removes the
+  cap.
 
-- **`--no-body-width`** — Let the body use the full terminal width.
+- **`--no-body-width`** — Lay the body out at the full terminal width.
 
-- **`--theme NAME`** — The theme to start in.
+- **`--theme NAME`** — Start in theme *NAME*.
 
-- **`--icons`** — Use Nerd Font glyphs even if none appears to be installed.
+- **`--icons`** — Use Nerd Font glyphs even when none is detected.
 
 - **`--no-icons`** — Use plain Unicode instead of Nerd Font glyphs, at the same display
   width.
 
-- **`--mouse`** — Capture the mouse: the wheel scrolls, the scrollbar drags, clicks jump
-  in the contents pane, and dragging over the document copies the Markdown source behind
-  it.
+- **`--mouse`** — Capture the mouse: the wheel scrolls, the scrollbar drags, a click in
+  the contents pane jumps, and a drag over the document copies the Markdown source
+  behind it.
 
-- **`--toc`** — Start with the table-of-contents pane open.
+- **`--toc`** — Start with the contents pane open.
 
-- **`--config PATH`** — Read configuration from this file instead of the default.
+- **`--config PATH`** — Read the configuration from *PATH* instead of the default file.
 
 - **`--licenses`** — Print the licences of the bundled syntax definitions and exit.
 
-- **`-h`, `--help`** — Print help and exit.
+- **`-h`, `--help`** — Print a usage summary and exit.
 
 - **`-V`, `--version`** — Print the version and exit.
 
-There is no `--color` flag. The truecolour decision is made from whether standard
-output is a terminal, which is the same question `--render-once` already answers.
+There is no `--color` flag. Truecolour is used when standard output is a terminal.
 
 # KEYS
 
-Bindings are remappable; see `[keys]` under **CONFIGURATION**. The in-app help
-overlay is generated from the same live binding table as this list, so the two
-cannot drift apart, and the status bar always names the keys you have actually
-bound rather than the defaults.
+Bindings are remappable; see `[keys]` under **CONFIGURATION**. The help overlay
+and the status bar name the bindings in effect rather than the defaults.
 
-## Moving
+## Movement
 
 - **`j`, `Down`** — Scroll down one line.
 
@@ -94,8 +90,8 @@ bound rather than the defaults.
 
 - **`%`** — Jump N percent into the document, as in `50%`.
 
-- **`Left`, `Right`** — Scroll content that is wider than the terminal, such as a wide
-  table or a long code line. Neither is ever reflowed or mangled to fit.
+- **`Left`, `Right`** — Scroll content wider than the terminal, such as a wide table or a
+  long code line. Neither is reflowed.
 
 ## Structure
 
@@ -103,9 +99,9 @@ bound rather than the defaults.
 
 - **`]`** — Go to the next heading.
 
-- **`=`, `Ctrl-g`** — Report where you are.
+- **`=`, `Ctrl-g`** — Report the current position.
 
-- **`Tab`** — Show or hide the table of contents.
+- **`Tab`** — Show or hide the contents pane.
 
 - **`f`** — Move the keyboard cursor to the next link or button in the document,
   scrolling to bring it into view.
@@ -114,10 +110,10 @@ bound rather than the defaults.
   scrolling to bring it into view.
 
 - **`Enter`** — Jump to the selected heading, or follow the link or button under the
-  keyboard cursor. The status bar shows the full URL under the cursor, the same as it
-  does for a mouse hover, so `Enter` never sends you somewhere unseen.
+  keyboard cursor. The status bar shows the full URL under the cursor, as it does for a
+  mouse hover.
 
-## Searching
+## Search
 
 - **`/`** — Search forward.
 
@@ -129,121 +125,121 @@ bound rather than the defaults.
 
 - **`Ctrl-r`** — Switch between literal and regex search.
 
-## Other
+## Display and session
 
-- **`t`** — Switch to the next theme. This cycles through the built-ins and anything you
-  have defined.
+- **`t`** — Switch to the next theme, over the built-ins and any theme defined in the
+  configuration file.
 
 - **`-`** — Show or hide code line numbers.
 
-- **`S`** — Save the current settings for next time.
+- **`S`** — Save the current settings for the next run.
 
 - **`h`, `F1`** — Show or hide the help overlay.
 
-- **`Esc`** — Clear the search, or close the overlay or pane. It never quits.
+- **`Esc`** — Clear the search, or close the overlay or pane. `Esc` does not quit.
 
 - **`q`** — Quit.
 
-## Notes on a few of these
+## Notes
 
-Keys that take a count take it as a prefix: `10j`, `50%`.
+A key that takes a count takes it as a prefix: `10j`, `50%`.
 
-`Esc` unwinds one step at a time. It clears a search, then a filter, then returns
-focus from the contents pane, then closes it. It never quits; `q` does that.
+`Esc` unwinds one step per press. It clears a search, then a filter, then returns
+focus from the contents pane, then closes the pane. It does not quit; `q` does.
 
-`/` inside the contents pane filters the headings fuzzily instead of searching
-the document.
+`/` in the contents pane filters the headings fuzzily instead of searching the
+document.
 
-While a search is live the status bar carries the query and which match you are
-on out of how many there are, and, when there is more than one, the keys that
-step between them, with the `Ctrl` alternatives beside them when the terminal is
-wide enough. The current match is highlighted differently from the rest, and
-reaching one scrolls sideways as well as down, so a hit inside a wide table or a
-long code line is actually on screen when you arrive at it.
+While a search is live, the status bar carries the query and the current match
+number out of the total. With more than one match it also carries the keys that
+step between matches, and the `Ctrl` alternatives beside them when the terminal
+is wide enough. The current match is highlighted differently from the rest.
+Reaching a match scrolls sideways as well as down, so a match inside a wide table
+or a long code line is on screen on arrival.
 
-`S` writes the settings you can change from inside the pager --- theme, line
-numbers, contents pane, body width --- back to the configuration file, and tells
-you which file it wrote. It edits that file rather than regenerating it: your
-comments, your ordering and any key a newer **mdmost** understands are all still
-there afterwards, the previous version is kept as `config.toml.bak`, and a save
-whose result would not read back identically is refused rather than guessed at.
+`S` writes the settings that can be changed from inside the pager, which are the
+theme, the line numbers, the contents pane and the body width, back to the
+configuration file, and reports which file it wrote. It edits that file rather
+than regenerating it, so comments, key order and any key a newer **mdmost**
+understands survive the write. The previous file is kept as `config.toml.bak`. A
+save whose result would not read back identically is refused.
 
 # LINKS AND FOOTNOTES
 
-Clicking a link opens it in your browser; clicking a `#heading` reference scrolls
-that heading to the top of the viewport.
+With the mouse captured, a click on a link opens it in the browser, and a click
+on a `#heading` reference scrolls that heading to the top of the viewport.
 
-Both work with no `--mouse` flag. Press `f` (or `F` to go backward) to move a
-keyboard cursor from one link or button to the next anywhere in the document,
-scrolling to bring it on screen --- the same way `n` steps to the next search
-hit --- and `Enter` to follow whatever it is on. The status bar shows the full
-URL under the cursor exactly as it does for a mouse hover, so `Enter` never sends
-you somewhere unseen. `Esc` puts the cursor away.
+Both kinds are also reachable from the keyboard, with no `--mouse` needed. Press
+`f` to move a keyboard cursor to the next link or button anywhere in the
+document, `F` to move it to the previous one, and `Enter` to follow the one under
+it. The cursor scrolls the document to bring its target
+into view, in the way that `n` steps to the next search match. The status bar
+shows the full URL under the cursor, as it does for a mouse hover. `Esc` puts the
+cursor away.
 
-Only `http` and `https` links open. Anything else is shown as plain text and is
-wholly inert.
+Only `http` and `https` links open. Any other scheme is shown as plain text and
+is inert.
 
-Unlike the `[copy]` buttons described under **SELECTING AND COPYING**, links are
-never hidden when the mouse was not captured. A link is content, not chrome, and
-hiding it would mean hiding part of the document.
+Links are shown whether or not the mouse was captured. The `[copy]` buttons
+described under **SELECTING AND COPYING** are not.
 
 ## Footnotes
 
-A footnote marker opens the note in a box beside it, without moving the page.
-The box is anchored to the marker and placed in whichever gap above or below it
-has the room; on a screen too short for either it declines to open rather than
-covering the line you are reading. It is at most 60 columns wide, because a note
-that grows to fill a 200-column terminal stops reading as an aside.
+A footnote marker opens the note in a box beside it. The document does not move.
 
-The note is drawn by the ordinary renderer at the box's own width, so emphasis,
-code spans, nested lists and even tables inside a footnote all work. The cursor
-keys scroll the box while the document behind it holds still.
+The box is anchored to the marker and placed in whichever gap above or below the
+marker has the room. On a screen too short for either gap it does not open. It is
+at most 60 columns wide.
+
+The note is drawn by the ordinary renderer at the width of the box, so emphasis,
+code spans, nested lists and tables inside a footnote all render. The cursor keys
+scroll the box while the document behind it holds still.
 
 # SELECTING AND COPYING
 
-With `--mouse` (or `mouse = true`) a left drag over the document selects, and
-releasing puts the **Markdown source** behind the selection on the clipboard ---
-not the glyphs on screen. Dragging over a rendered heading copies the `#` and its
+With `--mouse` (or `mouse = true`) a left drag over the document selects, and the
+release puts the **Markdown source** behind the selection on the clipboard rather
+than the glyphs on screen. A drag over a rendered heading copies the `#` and its
 text; over a bold word, `**bold**`; over a link, `[text](url)`; across a code
-fence, the fence and its content verbatim. A drag that reflows across several
-rows copies the source's own line breaks, not the renderer's. `Esc` clears the
-highlight.
+fence, the fence and its content verbatim. A drag across rows that were reflowed
+copies the line breaks of the source. `Esc` clears the highlight.
 
-A code frame and a table each carry a `[copy]` in the right of their top edge.
-Pressing it copies the **whole block** --- the code exactly as it is written, the
-table as a grid of tab-separated cells that a spreadsheet splits into columns,
-with an HTML flavour offered alongside where the local clipboard takes one. The
-label reads `[copied]` for a moment and the status bar names what went out.
+A code frame and a table each carry a `[copy]` button at the right of their top
+edge. It copies the **whole block**: the code exactly as written, and the table as
+a grid of tab-separated cells that a spreadsheet splits into columns. An HTML
+flavour is offered alongside where the local clipboard takes one. The label reads
+`[copied]` for a moment and the status bar names what was sent.
 
-There is no key for the buttons and no setting. They appear only when the mouse
-was actually captured, because a control nobody can press is worse than none.
-They are dropped where they would not fit, and a table wider than the terminal
-carries its button off to the right until you scroll to it.
+The buttons have no key binding and no setting. They appear only when the mouse
+was captured. They are dropped where they would not fit, and a table wider than
+the terminal carries its button off to the right, where horizontal scrolling
+reaches it.
 
-Two things are worth knowing.
+Two points apply to what is copied.
 
-A selection over a Mermaid diagram has no source map to invert --- the renderer
-records one for inline text and for code lines, not for box art --- so it copies
-what is drawn instead, and the status bar says `rendered text` rather than
-`Markdown source`.
+A selection over a Mermaid diagram copies what is drawn rather than the source,
+and the status bar reports `rendered text` instead of `Markdown source`. The
+renderer records a source map for inline text and for code lines, not for box
+art.
 
-The copy goes out as OSC 52 first, which works over SSH but which the terminal
-never acknowledges. If that is the only route that ran, the status bar says
-`sent … (unconfirmed)` rather than `copied`. `tmux` needs
+The copy goes out as OSC 52 first, which works over `ssh` but which the terminal
+does not acknowledge. When that is the only route that ran, the status bar
+reports `sent … (unconfirmed)` instead of `copied`. `tmux` needs
 `set -g set-clipboard on` to pass it along, and `xterm` needs `allowWindowOps`.
-On a local display server the `arboard` fallback runs too and the report becomes
-`copied`.
+On a local display server the `arboard` fallback runs as well and the report
+becomes `copied`.
 
-Turning the mouse on is a trade: capturing it takes away the terminal's own
-drag-select, which outlives the pager and which your fingers already know.
+Capturing the mouse takes away the terminal's own drag-select for as long as
+**mdmost** runs.
 
 # CONFIGURATION
 
-TOML, at *~/.config/mdmost/config.toml*, or the platform's own configuration
-directory where that differs. `--config PATH` overrides it. See **FILES**.
+The configuration file is TOML, at *~/.config/mdmost/config.toml*, or in the
+platform's own configuration directory where that differs. `--config PATH`
+overrides it. See **FILES**.
 
-A broken configuration never stops the program from starting: the problem is
-reported and the rest of the file still applies, so one bad key binding costs you
+A broken configuration file does not stop the program from starting. The problem
+is reported and the rest of the file still applies, so one bad key binding costs
 that binding and nothing else.
 
 ```toml
@@ -272,24 +268,23 @@ green  = "#a6e3a1"
 ```
 
 Most command-line options have a configuration-file counterpart, and a few
-settings exist only there. In particular `title_banner` is `false` unless asked
-for: set `title_banner = true` to have a document whose first block is its one
-and only `#` heading drawn as a FIGlet banner. Section numbering,
-`section_numbers`, is on by default; the banner is not. Both are described under
-**RENDERING**.
+settings exist only in the file. `title_banner` is `false` unless set: with
+`title_banner = true`, a document whose first block is its one and only `#`
+heading is drawn with a FIGlet banner. `section_numbers` is `true` by default.
+Both are described under **RENDERING**.
 
 ## Themes
 
-A `[themes.<name>]` table inherits from `base` --- `"dark"` or `"light"` --- so a
-custom theme can be a two-line tweak rather than a full palette. The overridable
-colours are `bg`, `surface`, `overlay`, `fg`, `muted`, `border`, `accent`, `red`,
-`orange`, `yellow`, `green`, `cyan`, `blue` and `purple`, plus
-`dark = true|false` to tell the renderer which way the palette leans. `t` cycles
-through the built-ins and anything you have defined.
+A `[themes.<name>]` table inherits from `base`, which is `"dark"` or `"light"`,
+so a custom theme can override a single colour rather than a full palette. The
+overridable colours are `bg`, `surface`, `overlay`, `fg`, `muted`, `border`,
+`accent`, `red`, `orange`, `yellow`, `green`, `cyan`, `blue` and `purple`.
+`dark = true|false` tells the renderer which way the palette leans. `t` cycles
+through the built-ins and any theme defined here.
 
-## Whether icons are used
+## Icon settings
 
-Three settings answer the same question, in increasing order of authority:
+Three settings answer the same question. Each outranks the one before it:
 
 - **`icons = true` / `false`** — Settles it for this machine.
 
@@ -297,102 +292,94 @@ Three settings answer the same question, in increasing order of authority:
 
 - **`--icons` / `--no-icons`** — Settles it for this run.
 
-Omit all three and **mdmost** decides for itself. How it decides, and why it errs
-towards plain, is under **TERMINAL SETUP**.
+With none of the three set, **mdmost** detects whether to use icons. The
+detection is described under **TERMINAL SETUP**.
 
 # RENDERING
 
 ## Title banner
 
-Set `title_banner = true` and a document whose first block is its one and only
-`#` heading opens with that title in the FIGlet *Small* font, wrapped between
-words over as many lines as it needs and centred.
+With `title_banner = true`, a document whose first block is its one and only `#`
+heading opens with that title in the FIGlet *Small* font, wrapped between words
+over as many lines as it needs and centred.
 
-It is **off by default**: art in place of someone else's title is a decoration,
-and a default is the wrong place to hold that opinion. Turned on, it still
-declines --- and draws an ordinary heading --- when the title is not plain ASCII,
-or when a single word is too wide for the measure to break.
+The setting is **off by default**. Even when it is on, an ordinary heading is
+drawn instead when the title is not plain ASCII, or when a single word is too
+wide for the measure to break.
 
 ## Section numbers
 
-A document that nests three or more section levels gets section numbers --- `1`,
-`1.1`, `1.1.1` --- in front of its headings and in the contents pane, drawn in a
-quiet grey of their own so it is obvious they are **mdmost**'s and not the
-author's.
+A document that nests three or more section levels gets section numbers, `1`,
+`1.1` and `1.1.1`, in front of its headings and in the contents pane. They are
+drawn in a grey of their own, so they are distinguishable from numbers the author
+wrote.
 
-A lone `#` title is not a section: it stays unnumbered and its `##`s are numbered
-`1`, `2`, `3`. A flat document gets nothing, because it needs nothing.
+A lone `#` title is not a section: it stays unnumbered, and its `##` headings are
+numbered `1`, `2`, `3`. A document with fewer than three levels gets no numbers.
 `section_numbers = false` turns them off.
 
-Heading levels are also told apart by the rule underneath them --- heavy, light,
-then dashed. Headings have no marker in front of them.
+Heading levels are also told apart by the rule underneath them: heavy, then
+light, then dashed. Headings carry no marker in front of them.
 
 ## Syntax highlighting
 
 Fenced code is highlighted from the syntax definitions curated by the `bat`
-project --- a little over two hundred languages, compiled into the binary, so
-there is nothing to install and nothing to configure. That includes the ones a
-2020s README actually contains: TypeScript and TSX, Kotlin, Swift, Zig, Nix,
-TOML, Dockerfile, Terraform/HCL, Elixir, Dart, Julia, Protobuf, GraphQL, Vue,
-Svelte, Sass and SCSS, F#, CMake, Solidity, Nim, x86-64 assembly, `.env` files,
-`go.mod`, `nginx.conf` and `.gitignore`.
+project. A little over two hundred languages are compiled into the binary, so
+there is nothing to install and nothing to configure. The set includes TypeScript
+and TSX, Kotlin, Swift, Zig, Nix, TOML, Dockerfile, Terraform/HCL, Elixir, Dart,
+Julia, Protobuf, GraphQL, Vue, Svelte, Sass and SCSS, F#, CMake, Solidity, Nim,
+x86-64 assembly, `.env` files, `go.mod`, `nginx.conf` and `.gitignore`.
 
-Two definitions are missing on purpose. **PowerShell** and **ARM assembly** need
-regex features the pure-Rust engine cannot compile, and **mdmost** uses that
-engine so the build needs no C toolchain. They render as plain text, like any tag
-we do not know.
+**PowerShell** and **ARM assembly** are absent. They need regex features the
+pure-Rust engine cannot compile, and the build uses that engine so that no C
+toolchain is required. They render as plain text.
 
 The fence tag is matched against every syntax name and every file extension, so
-`rs`, `py`, `yml`, `sh`, `ts`, `tsx`, `kt`, `c++`, `hcl` and their friends all
-land where you would expect; a short table of aliases covers the rest (`golang`,
-`console`, `jsonc`, `csharp`, `fsharp`, `objc`, `plaintext`, and so on). Only the
-first word of the info string is read, so a fence tagged `rust,no_run` highlights
-as Rust. **A tag nobody recognises is never an error** --- the block is drawn as
-plain themed text, still framed, still with its label.
+`rs`, `py`, `yml`, `sh`, `ts`, `tsx`, `kt`, `c++` and `hcl` all resolve. A short
+table of aliases covers the rest, among them `golang`, `console`, `jsonc`,
+`csharp`, `fsharp`, `objc` and `plaintext`. Only the first word of the info
+string is read, so a fence tagged `rust,no_run` is highlighted as Rust. **An
+unrecognised tag is not an error**: the block is drawn as plain themed text,
+still framed and still with its label.
 
 Colours never come from the syntax definitions. Each scope is mapped to a
-semantic slot --- keyword, string, number, comment, type, namespace, escape ---
-and the slot is filled from the active **mdmost** theme, so code sits inside the
-palette instead of fighting it.
+semantic slot, which is one of keyword, string, number, comment, type, namespace
+and escape, and the slot takes its colour from the active theme.
 
 TOML and Dockerfile use definitions written for **mdmost** rather than the
-bundled ones, because the bundled TOML gives a `[table.header]` no scope at all
-and the bundled Dockerfile emits a whole `RUN` line as one undifferentiated span.
+bundled ones. The bundled TOML gives a `[table.header]` no scope at all, and the
+bundled Dockerfile emits a whole `RUN` line as one span.
 
 ## Line length
 
-Prose is capped at 72 columns by default and centred when the terminal is wider,
-because a line that runs the full width of a wide terminal is hard to come back
-from --- the eye loses the start of the next one. Set `body_width` (or
-`--body-width`) to taste, or `0` / `--no-body-width` to switch the cap off.
-Seventy-two is inside the readable band rather than at the top of it, so the cap
-bites on an 80-column terminal too --- but only on prose.
+Prose is capped at 72 columns by default and centred when the terminal is wider.
+Set `body_width`, or `--body-width`, to change the cap, and `0` or
+`--no-body-width` to switch it off. The default of 72 is inside the readable band
+rather than at the top of it, so the cap also bites on an 80-column terminal.
 
 The cap is about text that can be reflowed, so it does not apply to everything:
 
 - **Tables and Mermaid diagrams ignore the cap** and are laid out at the full
-  terminal width. Both stop at their natural width --- a table does not stretch
-  its columns to fill the room, and a diagram is drawn at the narrowest width
-  that works --- so this costs nothing when they are small. Wherever it ends up,
-  a block is centred on the same axis as the prose rather than stranded at the
-  left edge; only something as wide as the terminal starts at the margin.
+  terminal width. Both stop at their natural width: a table does not stretch its
+  columns to fill the room, and a diagram is drawn at the narrowest width that
+  works. Wherever a block ends up, it is centred on the same axis as the prose;
+  only a block as wide as the terminal starts at the margin.
 - **Everything else takes the full width as soon as the cap would cut it short.**
-  That is what a fenced code block gets: a short snippet sits with the prose, and
-  a block with a long line takes the whole terminal. The same applies to a wide
-  table or fence nested inside a block quote or list item.
-- Content wider than the terminal itself is unaffected by any of this. It is
-  still laid out at the width it needs and reached with `Left` and `Right`.
+  A short fenced snippet sits with the prose, and a block with a long line takes
+  the whole terminal. The same applies to a wide table or fence nested inside a
+  block quote or a list item.
+- Content wider than the terminal itself is unaffected. It is laid out at the
+  width it needs and reached with `Left` and `Right`.
 
-`--width` is a different setting and does not replace this one: it changes the
+`--width` is a different setting and does not replace this one. It changes the
 width the whole document is rendered at, including tables and code.
-`--body-width` caps only the prose within whatever that width is.
+`--body-width` caps the prose within that width.
 
 ## Mermaid
 
 Fenced `mermaid` blocks are parsed and drawn as Unicode box art. All seven
-families are supported; anything outside the supported subset degrades to a
-syntax-highlighted code block with a dim caption saying why, so a diagram never
-takes the document down with it.
+families are supported. Anything outside the supported subset degrades to a
+syntax-highlighted code block with a dim caption stating the reason.
 
 - **`flowchart` / `graph`** — Directions `TD`/`TB`/`LR`/`RL`/`BT`; shapes `[rect]`,
   `(round)`, `([stadium])`, `{rhombus}`, `((circle))`, `[[subroutine]]`, `[(cylinder)]`;
@@ -417,8 +404,7 @@ takes the document down with it.
   `note right of`.
 
 - **`pie`** — `title`, `showData`, `"label" : value`. Drawn as a sorted bar chart with
-  percentages --- a circle in character cells reads badly, so bars are the honest
-  choice.
+  percentages, because a circle in character cells reads badly.
 
 - **`gantt`** — `title`, `dateFormat`, `axisFormat`, `section`, tasks with `after X`,
   durations or explicit dates, and `done`/`active`/`crit`/`milestone` tags. The time
@@ -426,48 +412,43 @@ takes the document down with it.
 
 Directives, `%%` comments and `%%{init}%%` blocks are parsed and ignored.
 
-## Rules worth knowing
+## Layout rules
 
-**Everything is width-driven.** No layout decision is taken at parse time, so a
-resize re-renders rather than patching. Table columns are negotiated against the
-available width; a cell is itself a nested document, so Markdown inside a table
-cell works.
+**Layout is width-driven.** No layout decision is taken at parse time, so a
+resize renders the document again rather than patching it. Table columns are
+negotiated against the available width. A cell is itself a nested document, so
+Markdown inside a table cell renders.
 
 **A table whose rows wrap gets air between them.** While every row fits on one
-line the table is drawn dense. As soon as one row wraps, a blank line goes
-between every pair of rows, because multi-line rows packed edge to edge read as
-one block of prose. The zebra stripe is carried through the gap by a half block,
-so the shading still groups each row's lines. This is decided at the width you
-are reading at, so the same table is dense in a wide terminal and spaced in a
+line, the table is drawn dense. As soon as one row wraps, a blank line goes
+between every pair of rows. The zebra stripe is carried through the gap by a half
+block, so the shading still groups the lines of each row. The decision is made at
+the width in use, so the same table is dense in a wide terminal and spaced in a
 narrow one.
 
-**Grapheme-safe throughout.** Widths are display columns, never bytes or
-characters. Combining marks, ZWJ emoji sequences and regional-indicator flags are
-never split, and every row the pager draws is padded to exactly the width of the
-pane.
+**Widths are display columns**, never bytes and never characters. Combining
+marks, ZWJ emoji sequences and regional-indicator flags are never split, and
+every row is padded to exactly the width of its pane.
 
-**Wide content scrolls, it does not mangle.** A table or code line too wide for
-the terminal keeps its shape and is reached with `Left` and `Right`. A cut line
-is marked at the edge --- one marker for content continuing to the right, another
-once you have scrolled --- while a box's own rules close with the corner they
-belong to, so the frame still reads as a box that continues.
+**Wide content scrolls.** A table or code line too wide for the terminal keeps
+its shape and is reached with `Left` and `Right`. A cut line is marked at the
+edge, with one marker for content continuing to the right and another once the
+view has scrolled, while a box's own rules close with the corner they belong to.
 
-**Lists and task boxes are ASCII.** The bullets (`*`, `>`, `+`, `-`, one per
-nesting level) and the task boxes (`[ ]`, `[x]`) are ASCII whether or not a Nerd
-Font is present. Lists turn up in nearly every document, so their markers are the
-things on the page that can least afford to be invisible --- and most of these
-are the literal Markdown the author typed.
+**List bullets and task boxes are ASCII.** The bullets are `*`, `>`, `+` and `-`,
+one per nesting level, and the task boxes are `[ ]` and `[x]`. Both are ASCII
+whether or not a Nerd Font is present.
 
-**No HTML, and no raster images.** Raw HTML in the source is skipped rather than
-rendered or shown. An image becomes a captioned placeholder with its alt text and
-target; there is no sixel and no kitty protocol.
+**HTML and raster images are not rendered.** Raw HTML in the source is skipped
+rather than rendered or shown. An image becomes a captioned placeholder carrying
+its alt text and its target. There is no sixel support and no kitty graphics
+protocol.
 
 # TERMINAL SETUP
 
-**mdmost** draws with characters from the Unicode blocks below. Your terminal
-font, or a fallback behind it, has to cover them. This is a statement about
-coverage, not about which font you should use: any font or chain that covers
-these will do.
+**mdmost** draws characters from the Unicode blocks below. The terminal font, or
+a fallback behind it, has to cover them. Any font or font chain with that
+coverage will do.
 
 - **Box Drawing (U+2500-U+257F)** — Every table border, code frame and diagram box.
 
@@ -489,37 +470,35 @@ these will do.
 - **Specials (U+FFF0-U+FFFF)** — The replacement character, drawn in place of one that
   cannot be represented.
 
-- **Private Use Area (U+E000-U+F8FF)** — Code-fence language icons --- **only when icons
-  are on**.
+- **Private Use Area (U+E000-U+F8FF)** — Code-fence language icons, drawn **only when
+  icons are on**.
 
-The Private Use Area row is the one you can opt out of, with `--no-icons`.
-Everything above it is drawn whatever you do.
+The Private Use Area row is the only optional one, and `--no-icons` removes it.
+Every row above it is drawn regardless.
 
-The interface adds one block the document never needs: **Arrows**
-(U+2190-U+21FF), for the `Ctrl` key hints the status bar shows beside a live
-search, and the search indicator itself.
+The interface adds one block that no document needs: **Arrows**
+(U+2190-U+21FF), for the `Ctrl` key hints beside a live search, and for the
+search indicator itself.
 
-The document's own text is not on this list and cannot be. A font that does not
-cover the language you are reading was already a problem before **mdmost**
-opened it.
+The text of the document is not on this list and cannot be. Covering the language
+of the document is the font's business in any program.
 
-## What goes wrong without it
+## Symptoms of missing glyphs
 
-A missing glyph is not usually a blank box. The terminal falls back to another
-font, and that font's advance width need not match the base font's --- so a line
-made *entirely* of box characters comes out a different width from the text lines
-around it, and the frame stops lining up. A table's rules overshoot its contents;
-a diagram's boxes shear.
+A missing glyph is usually not a blank box. The terminal falls back to another
+font, and the advance width of that font need not match the base font's. A line
+made *entirely* of box characters then comes out at a different width from the
+text lines around it, and the frame stops lining up. A table's rules overshoot
+its contents, and a diagram's boxes shear.
 
-This is not something **mdmost** can correct from the inside. Every row it draws
-is padded to exactly the width of the pane, measured in display columns; what the
-terminal then does with those columns is the font stack's business.
+**mdmost** cannot correct this from the inside. Every row it draws is padded to
+exactly the width of the pane, measured in display columns. What the terminal
+then does with those columns belongs to the font stack.
 
-If you have seen these frames misalign in a web browser, that is the same fault
-one layer up. GitHub strips CSS from Markdown, so the font stack there is not
-ours to set either.
+The same misalignment in a web browser has the same cause one layer up. GitHub
+strips CSS from Markdown, so the font stack there is not settable either.
 
-## Fixing it
+## Font fallback configuration
 
 On Linux, fontconfig decides. Put a fallback chain in
 *~/.config/fontconfig/fonts.conf* and run `fc-cache -f`:
@@ -539,71 +518,64 @@ On Linux, fontconfig decides. Put a fallback chain in
 </fontconfig>
 ```
 
-On macOS and Windows fontconfig is not in play and the terminal decides. Set the
-fallback in the terminal's own font settings --- iTerm2 has a separate font for
+On macOS and Windows, fontconfig is not involved and the terminal decides. Set
+the fallback in the terminal's own font settings. iTerm2 has a separate font for
 non-ASCII text, Windows Terminal takes a font fallback list in its
 *settings.json*, and Kitty and WezTerm both take an explicit fallback list in
-their configuration.
+their configuration files.
 
-## A stack known to work
+## A known-good font stack
 
-This trio, consulted in that order, covers everything **mdmost** draws:
+These three fonts, consulted in this order, cover everything **mdmost** draws:
 
 - **JetBrains Mono** — The text font.
 
 - **Symbols Nerd Font** — The Private Use Area icons.
 
-- **JuliaMono** — Unicode's symbol blocks --- arrows, geometric shapes, dingbats,
+- **JuliaMono** — Unicode's symbol blocks: arrows, geometric shapes, dingbats and
   braille.
 
-It is named because it is known to work, not because **mdmost** wants it.
+## Icon detection
 
-## Icons are detected, not assumed
+A terminal cannot be asked which font it is using. **mdmost** therefore asks
+fontconfig whether an installed font covers every glyph it would draw, and uses
+icons only when one does.
 
-No terminal can be asked what font it is using. So **mdmost** asks fontconfig
-whether an installed font covers every glyph it would draw, and uses icons only
-if one does.
-
-It picks plain whenever it cannot establish that: when `fc-list` is unavailable,
-when output is not going to a terminal, on `TERM=dumb` or the Linux console, and
-**over SSH**, where the fonts on the machine running **mdmost** say nothing about
-the terminal drawing the pixels.
-
-Guessing wrong towards plain costs a little elegance; guessing wrong towards
-icons fills the screen with replacement boxes. The tie does not go to the
-prettier answer.
+It uses plain glyphs whenever it cannot establish that: when `fc-list` is
+unavailable, when output is not going to a terminal, on `TERM=dumb` and on the
+Linux console, and over `ssh`, where the fonts on the machine running **mdmost**
+say nothing about the terminal drawing the pixels.
 
 Plain and icon glyphs occupy **the same display width**, so nothing shifts and
-nothing reflows either way --- the difference is what the markers look like,
-never where anything sits, and no feature is lost. To decide for yourself rather
-than let it detect, see **CONFIGURATION**.
+nothing reflows either way, and no feature depends on icons. To settle the choice
+by hand instead, see **CONFIGURATION**.
 
 # DEFAULT MARKDOWN VIEWER
 
-Two unrelated mechanisms can hand a Markdown file to **mdmost**. Which one you
-want depends on where you click.
+Two unrelated mechanisms can hand a Markdown file to **mdmost**. Which one
+applies depends on where the file is clicked.
 
-- **The desktop's file association** — What a file manager consults when you
-  double-click *notes.md*. It is a registry belonging to the operating system, and
-  on Linux it is an open standard that any program may register with.
+- **The desktop's file association** — What a file manager consults when *notes.md*
+  is double-clicked. It is a registry belonging to the operating system, and on Linux
+  it is an open standard that any program may register with.
 
-- **The terminal's own link handling** — What runs when you click a `file://` link
-  in terminal output. The terminal settles this itself, before the operating system
-  is ever consulted, so it is configured once per terminal and behaves the same on
-  Linux and on macOS.
+- **The terminal's own link handling** — What runs when a `file://` link in terminal
+  output is clicked. The terminal settles this itself, before the operating system is
+  consulted, so it is configured once per terminal and behaves the same on Linux and
+  on macOS.
 
-On macOS only the second is open to **mdmost**. Launch Services binds a file type
-to an *application bundle*, and a program that draws in a terminal has no bundle to
-register. That is why the macOS instructions below are per terminal rather than
-system-wide, and it is not a gap that a package can close.
+On macOS only the second is available to **mdmost**. Launch Services binds a file
+type to an *application bundle*, and a program that draws in a terminal has no
+bundle to register. The macOS instructions below are therefore per terminal
+rather than system-wide.
 
-Neither mechanism is how you make **mdmost** the pager that other command-line
-programs reach for; for that see `PAGER` under **ENVIRONMENT**.
+Neither mechanism makes **mdmost** the pager that other command-line programs
+reach for. For that, see `PAGER` under **ENVIRONMENT**.
 
-## The desktop file association on Linux
+## Desktop file association on Linux
 
-Markdown's registered media type is `text/markdown`. Describe **mdmost** to the
-desktop in *~/.local/share/applications/mdmost.desktop*:
+The registered media type for Markdown is `text/markdown`. Describe **mdmost** to
+the desktop in *~/.local/share/applications/mdmost.desktop*:
 
 ```ini
 [Desktop Entry]
@@ -623,56 +595,56 @@ update-desktop-database ~/.local/share/applications
 xdg-mime default mdmost.desktop text/markdown
 ```
 
-`xdg-mime query default text/markdown` now answers `mdmost.desktop`.
+`xdg-mime query default text/markdown` then answers `mdmost.desktop`.
 
-Three things about that file are worth knowing:
+Three properties of that file matter:
 
 - **`Terminal=true` is the weak part** — **mdmost** needs a terminal, so the desktop
-  has to find a terminal emulator to put it in. Which one it settles on, and whether
-  it manages to settle on one at all, has changed more than once. A double-click
-  that appears to do nothing is this, and the per-terminal setup below is the more
+  has to find a terminal emulator to run it in. Which one it settles on, and whether
+  it settles on one at all, differs between desktops and versions. A double-click that
+  appears to do nothing has this cause, and the per-terminal setup below is the more
   dependable answer.
 
 - **`text/x-markdown` needs no line of its own** — The shared-mime-info database
   declares it an alias of `text/markdown`, so it resolves through it.
 
-- **`Exec` is resolved on `PATH`** — A bare `mdmost` is right here, and it is what
-  a packaged copy of this file has to say.
+- **`Exec` is resolved on `PATH`** — A bare `mdmost` is correct here, and it is what a
+  packaged copy of this file has to say.
 
-The `.deb` and the `.rpm` install that entry to */usr/share/applications* already, so
-on those there is nothing to write: **mdmost** is offered for a Markdown file to every
-user on the machine, and only the `xdg-mime` line above is left to you. Write the file
-yourself when you installed from Homebrew or the tarball, or when you want it for one
-account rather than all of them.
+The `.deb` and the `.rpm` install that entry to */usr/share/applications*, so on
+those there is nothing to write: **mdmost** is offered for a Markdown file to
+every user on the machine, and only the `xdg-mime` line above is left. Write the
+file by hand after a Homebrew or tarball installation, or to register **mdmost**
+for one account rather than all of them.
 
-What no package does, and none should, is decide which application wins. Declaring
-that **mdmost** *can* open Markdown is a package's business; setting the default is
-the user's. The freedesktop specification reserves a system-wide *mimeapps.list* for
-the desktop environment, so a package that shipped one would be taking the
-association away from every editor on the machine.
+No package settles which application wins. A package declares that **mdmost**
+*can* open Markdown; the `xdg-mime` line above sets the default. The freedesktop
+specification reserves a system-wide *mimeapps.list* for the desktop
+environment, so a package that shipped one would take the association away from
+every editor on the machine.
 
-## Clicking a file:// link in the terminal
+## Terminal file:// link handling
 
-A terminal turns `file:///path/to/notes.md` in its output into a link and hands it
-to the operating system's opener when clicked. The terminals below can be told to
-run something else instead, which keeps the whole business inside the terminal:
-nothing to register, and the same configuration on both platforms.
+A terminal turns `file:///path/to/notes.md` in its output into a link and hands
+it to the operating system's opener when it is clicked. The terminals below can
+be told to run something else instead, which keeps the whole business inside the
+terminal: nothing to register, and the same configuration on both platforms.
 
 Two points apply to all of them:
 
-- **Name mdmost by absolute path** — These terminals execute the program directly
-  rather than through a shell, so it is looked up on the terminal's own `PATH`, and a
-  terminal launched from the macOS Dock inherits a bare `PATH` with no Homebrew
-  prefix in it. Use the output of `command -v mdmost`.
+- **Name mdmost by absolute path** — These terminals run the program directly rather
+  than through a shell, so it is looked up on the terminal's own `PATH`, and a terminal
+  launched from the macOS Dock inherits a bare `PATH` with no Homebrew prefix in it.
+  Use the output of `command -v mdmost`.
 
 - **A link stops at whitespace** — The usual link patterns match runs of non-space
-  characters, so a path holding a literal space is only recognised as far as the
-  space. Percent-encode it as `%20`.
+  characters, so a path holding a literal space is recognised only as far as the space.
+  Percent-encode it as `%20`.
 
 ### WezTerm
 
 WezTerm emits an `open-uri` event before it hands a link to the operating system,
-and a handler returning `false` suppresses that hand-off. In
+and a handler that returns `false` suppresses that hand-off. In
 *~/.config/wezterm/wezterm.lua*:
 
 ```lua
@@ -713,16 +685,16 @@ wezterm.on('open-uri', function(window, pane, uri)
 end)
 ```
 
-Returning nothing for everything else is what keeps `https` going to the browser
-and a remote host's `file://` out of a pager that has no such file to open. Do not
-reach for `wezterm.glob` to locate the binary: it is an async function, and calling
-it from a required module raises *attempt to yield across a C-call boundary*, which
-looks exactly like the binary not being installed.
+Returning nothing for every other URI keeps `https` links going to the browser
+and keeps a remote host's `file://` out of a pager that has no such file to open.
+Do not use `wezterm.glob` to locate the binary: it is an async function, and
+calling it from a required module raises *attempt to yield across a C-call
+boundary*, which looks exactly like the binary not being installed.
 
 ### Kitty
 
-Kitty reads *~/.config/kitty/open-actions.conf*, at that same path on Linux and on
-macOS. A stanza is match lines followed by action lines:
+Kitty reads *~/.config/kitty/open-actions.conf*, at that same path on Linux and
+on macOS. A stanza is match lines followed by action lines:
 
 ```
 protocol file
@@ -730,18 +702,18 @@ ext md,markdown,mkd,mdown
 action launch --type=os-window /opt/homebrew/bin/mdmost ${FILE_PATH}
 ```
 
-`${FILE_PATH}` arrives decoded and unquoted, so there is nothing left to unescape.
-Add `--title ${FILE}` to name the window after the document, and drop
-`--type=os-window` for a new tab in the window you clicked in instead.
+`${FILE_PATH}` arrives decoded and unquoted, so there is nothing to unescape. Add
+`--title ${FILE}` to name the window after the document. Omit `--type=os-window`
+for a new tab in the window that was clicked in.
 
 ### iTerm2
 
-iTerm2 has no per-scheme hook. What it has is Semantic History, under **Settings
--> Profiles -> Advanced**: set it to **Run command...**, where `\1` stands for the
-path. Two things make it the coarser instrument. It fires on a Cmd-click over a
-filename rather than over a `file://` link, and it fires for every file rather than
-for Markdown alone --- so the command has to be a small script of your own that
-looks at the extension and hands anything else to an editor.
+iTerm2 has no per-scheme hook. It has Semantic History, under **Settings ->
+Profiles -> Advanced**: set it to **Run command...**, where `\1` stands for the
+path. Semantic History is the coarser instrument. It fires on a Cmd-click over a
+filename rather than over a `file://` link, and it fires for every file rather
+than for Markdown alone, so the command has to be a script that inspects the
+extension and hands anything else to an editor.
 
 ### Terminal.app
 
@@ -751,22 +723,21 @@ Launch Services and offers no way to intervene.
 # ENVIRONMENT
 
 - **`MDMOST_ICONS`** — `1` or `0` forces Nerd Font glyphs on or off. It outranks the
-  configuration file and is outranked by `--icons` and `--no-icons`. Exporting it in a
-  profile is the natural thing to do on a server you always reach from the same
-  well-equipped terminal.
+  configuration file and is outranked by `--icons` and `--no-icons`. Export it in a
+  profile on a server that is always reached from the same well-equipped terminal.
 
-- **`PAGER`** — **mdmost** is usable as a pager; `export PAGER=mdmost` is the intended
-  use.
+- **`PAGER`** — **mdmost** can serve as the pager for other programs:
+  `export PAGER=mdmost`.
 
 # FILES
 
-- ***~/.config/mdmost/config.toml*** — Configuration, in TOML. A broken file never stops
-  the program from starting: the problem is reported and the rest of the file still
-  applies, so one bad key binding costs you that binding and nothing else. The
+- ***~/.config/mdmost/config.toml*** — Configuration, in TOML. A broken file does not
+  stop the program from starting: the problem is reported and the rest of the file
+  still applies, so one bad key binding costs that binding and nothing else. The
   platform's own configuration directory is used where it differs.
 
-- ***config.toml.bak*** — The previous configuration, kept beside it whenever `S` writes
-  a new one.
+- ***config.toml.bak*** — The previous configuration, kept beside the file whenever `S`
+  writes a new one.
 
 # EXIT STATUS
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,60 @@
+# Integrations
+
+Configuration fragments that make **mdmost** the thing that opens a Markdown file.
+
+One of them a package can install for you; the other two it cannot. The desktop
+entry belongs to the operating system, so the deb and the rpm install it system-wide
+and every user on the machine gets it. The terminal fragments belong to a terminal,
+and no terminal here has a drop-in directory a package could use — WezTerm and kitty
+each read one file owned by you — so those are yours to copy.
+
+| Fragment | deb, rpm | Homebrew, tarball |
+| -------- | -------- | ----------------- |
+| `xdg/mdmost.desktop` | installed to `/usr/share/applications` | copy it yourself |
+| `wezterm/md-open.lua` | example in `/usr/share/doc/mdmost/examples` | copy it yourself |
+| `kitty/open-actions.conf` | example in `/usr/share/doc/mdmost/examples` | copy it yourself |
+
+Homebrew keeps all three under `$(brew --prefix mdmost)/share/mdmost/integrations`.
+It installs no desktop entry: on macOS there is no such mechanism to install into,
+and on Linux its prefix is not on the desktop session's `XDG_DATA_DIRS`, so a file
+manager would never look there.
+
+`mdmost`(1), under **DEFAULT MARKDOWN VIEWER**, explains what each of these does and
+why the two mechanisms involved are not interchangeable.
+
+## What is here
+
+- `wezterm/md-open.lua` — Clicking a `file://…md` link in WezTerm opens it in a new
+  window running mdmost. Copy it next to your `wezterm.lua` and add
+  `require 'md-open'`; WezTerm's `package.path` already covers that directory.
+
+- `kitty/open-actions.conf` — The same, for kitty. Copy it to
+  `~/.config/kitty/open-actions.conf`, or append the stanza to the file you have.
+
+- `xdg/mdmost.desktop` — The Linux desktop file association, for double-clicking a
+  `.md` file in a file manager. Installing it only offers mdmost as a choice; to make
+  it the one a double-click uses:
+
+  ```sh
+  xdg-mime default mdmost.desktop text/markdown
+  ```
+
+  Installing from Homebrew or the tarball instead? Copy it to
+  `~/.local/share/applications/`, run `update-desktop-database` on that directory,
+  then the command above.
+
+Two terminals are deliberately absent. iTerm2 has no per-scheme hook — its Semantic
+History fires on any Cmd-clicked filename, so it needs a dispatch script of your own
+rather than a fragment. Terminal.app offers nothing to configure at all.
+
+## Set the path to mdmost
+
+Every fragment has to name the binary. WezTerm and kitty both execute it directly
+instead of going through a shell, so it is looked up on the *terminal's* `PATH` — and
+a terminal launched from the macOS Dock inherits a bare `PATH` with no Homebrew
+prefix in it. The Lua module searches the usual prefixes; the kitty stanza has the
+path written in, so change it to the output of:
+
+```sh
+command -v mdmost
+```

--- a/integrations/kitty/open-actions.conf
+++ b/integrations/kitty/open-actions.conf
@@ -1,0 +1,20 @@
+# Open Markdown file:// links in a new kitty window running mdmost.
+#
+# Copy this to ~/.config/kitty/open-actions.conf -- the same path on Linux and on
+# macOS -- or append the stanza to the file you already have. Nothing else is
+# needed: kitty consults this before handing a clicked link to the operating
+# system, so there is no file association to register.
+#
+# Change the path below to the output of `command -v mdmost`. It has to be
+# absolute: kitty executes the program directly rather than through a shell, and a
+# kitty launched from the macOS Dock inherits a bare PATH with no Homebrew prefix
+# in it.
+#
+# ${FILE_PATH} arrives percent-decoded and unquoted, so a path with spaces in it
+# needs no quoting here. Add `--title ${FILE}` to name the window after the
+# document, or drop `--type=os-window` to get a new tab in the window you clicked
+# in instead.
+
+protocol file
+ext md,markdown,mkd,mdown
+action launch --type=os-window /opt/homebrew/bin/mdmost ${FILE_PATH}

--- a/integrations/wezterm/md-open.lua
+++ b/integrations/wezterm/md-open.lua
@@ -1,0 +1,125 @@
+-- Open Markdown file:// links in a new WezTerm window running mdmost.
+--
+-- Copy this file next to your wezterm.lua -- WezTerm's package.path already
+-- covers that directory -- and require it:
+--
+--   require 'md-open'
+--
+-- Requiring it is what installs the handler; there is nothing else to call.
+--
+-- This needs nothing from the operating system. OpenLinkAtMouseCursor emits the
+-- `open-uri` event BEFORE it hands the URI to the OS opener, and returning false
+-- from the handler suppresses that hand-off. So there is no Launch Services
+-- registration on macOS, no application bundle, and no xdg-mime default on Linux:
+-- the terminal that draws the link is also the one that opens it, and these same
+-- lines behave identically on both platforms.
+local wezterm = require 'wezterm'
+
+local M = {}
+
+-- mdmost has to be named by absolute path. SpawnCommand executes argv directly
+-- rather than through a shell, so it resolves against WezTerm's own PATH -- and a
+-- WezTerm started from the macOS Dock inherits the bare launchd PATH, which has no
+-- Homebrew prefix in it. Put `command -v mdmost` at the front of this list if it
+-- lives somewhere else; the bare name at the end keeps the handler working wherever
+-- PATH does happen to be right.
+local CANDIDATES = {
+  '/opt/homebrew/bin/mdmost', -- Homebrew, Apple Silicon
+  '/usr/local/bin/mdmost',    -- Homebrew, Intel
+  '/usr/bin/mdmost',          -- deb, rpm
+  '/bin/mdmost',
+}
+
+-- io.open rather than wezterm.glob. glob is an async function: it yields, so
+-- calling it from a module chunk raises "attempt to yield across a C-call
+-- boundary" and every candidate silently looks absent -- which is
+-- indistinguishable from mdmost not being installed. io.open is plain Lua and
+-- works in any context.
+local function exists(path)
+  local handle = io.open(path, 'r')
+  if handle then
+    handle:close()
+    return true
+  end
+  return false
+end
+
+local function first_present(paths)
+  for _, path in ipairs(paths) do
+    if exists(path) then
+      return path
+    end
+  end
+  return 'mdmost'
+end
+
+local MDMOST = first_present(CANDIDATES)
+
+local MARKDOWN_EXT = {
+  md = true,
+  markdown = true,
+  mkd = true,
+  mdown = true,
+}
+
+-- Turns file:///a/b.md into /a/b.md, and returns nil for every URI that is not a
+-- Markdown file on this machine.
+local function md_path(uri)
+  local rest = uri:match '^file://(.*)$'
+  if not rest then
+    return nil
+  end
+
+  -- Strip a fragment or query before decoding. A '#' or '?' that genuinely belongs
+  -- to a filename arrives percent-encoded, so anything literal at this point is a
+  -- URI delimiter rather than a character to keep.
+  rest = rest:gsub('[#?].*$', '')
+
+  -- An empty authority and 'localhost' both mean this machine. A real hostname
+  -- means someone else's filesystem, where there is no local file to page.
+  local host, path = rest:match '^([^/]*)(/.*)$'
+  if not path or (host ~= '' and host ~= 'localhost') then
+    return nil
+  end
+
+  path = path:gsub('%%(%x%x)', function(hex)
+    return string.char(tonumber(hex, 16))
+  end)
+
+  local ext = path:match '%.(%a+)$'
+  if not ext or not MARKDOWN_EXT[ext:lower()] then
+    return nil
+  end
+  return path
+end
+
+wezterm.on('open-uri', function(window, pane, uri)
+  local path = md_path(uri)
+  if not path then
+    -- Not ours. Returning no value leaves WezTerm to open it as it always would,
+    -- which is what keeps http and https going to the browser.
+    return
+  end
+
+  -- Run in the document's own directory, so relative links and images resolve the
+  -- way they do for anything else reading the file.
+  local dir = path:match '^(.*)/[^/]*$'
+  if dir == nil or dir == '' then
+    dir = '/'
+  end
+
+  window:perform_action(
+    wezterm.action.SpawnCommandInNewWindow {
+      args = { MDMOST, path },
+      cwd = dir,
+    },
+    pane
+  )
+  return false
+end)
+
+-- Exposed so the URI matching can be exercised without a GUI.
+M.md_path = md_path
+M.mdmost = MDMOST
+
+return M

--- a/integrations/xdg/mdmost.desktop
+++ b/integrations/xdg/mdmost.desktop
@@ -1,0 +1,21 @@
+# Declares that mdmost can open Markdown, so a file manager offers it. It does not
+# claim the association: choosing the default is the user's business, with
+# `xdg-mime default mdmost.desktop text/markdown`.
+#
+# text/x-markdown needs no line of its own -- shared-mime-info declares it an alias
+# of text/markdown, so it resolves through it.
+#
+# Terminal=true is the weak part of this route. mdmost needs a terminal, so the
+# desktop has to find a terminal emulator to put it in, and which one it settles on
+# -- or whether it settles on one at all -- has changed more than once. A
+# double-click that appears to do nothing is this; the terminal fragments beside this
+# file are the more dependable answer.
+
+[Desktop Entry]
+Type=Application
+Name=mdmost
+Comment=Read a Markdown document in the terminal
+Exec=mdmost %f
+Terminal=true
+MimeType=text/markdown;
+Categories=Utility;TextEditor;ConsoleOnly;


### PR DESCRIPTION
Two unrelated mechanisms can hand a `.md` file to mdmost, and conflating them is what makes this confusing:

- **The desktop's file association** — what a file manager consults on a double-click. It belongs to the operating system.
- **The terminal's own link handling** — what runs when you click a `file://` link in terminal output. The terminal settles this itself, before the OS is ever consulted, so it needs nothing registered and behaves the same on Linux and macOS.

On macOS only the second exists for us: Launch Services binds a file type to an *application bundle*, and a program that draws in a terminal has none. That is not a gap a package can close.

## `integrations/`

| Fragment | What it does |
| --- | --- |
| `wezterm/md-open.lua` | An `open-uri` handler — a click opens the document in a new window running mdmost |
| `kitty/open-actions.conf` | The same, as a `protocol`/`ext` stanza |
| `xdg/mdmost.desktop` | The Linux desktop file association |

## How each is shipped

| Fragment | deb / rpm | Homebrew, tarball |
| --- | --- | --- |
| `xdg/mdmost.desktop` | installed to `/usr/share/applications` | copy it yourself |
| `wezterm/md-open.lua` | example in `/usr/share/doc/mdmost/examples` | copy it yourself |
| `kitty/open-actions.conf` | example in `/usr/share/doc/mdmost/examples` | copy it yourself |

The desktop entry is **installed for real** by the deb and the rpm. Those are system-wide installs, so every user on the machine should be offered mdmost for a Markdown file. It only declares the capability — **no `mimeapps.list` is shipped**, so which application wins stays each user's own `xdg-mime` call and no editor loses an association it had. The freedesktop spec reserves a system-wide `mimeapps.list` for the desktop environment anyway.

The terminal fragments *cannot* be installed that way, and that is a fact about the terminals rather than a choice: neither WezTerm nor kitty has a drop-in directory, and each reads one file owned by the user, so any system path a package chose would be one nothing reads. They go in as examples, at the location Debian Policy 12.6 names.

Homebrew keeps all three under `pkgshare` and installs no desktop entry: on macOS there is no such mechanism, and on Linux its prefix is not on a desktop session's `XDG_DATA_DIRS`, so a file manager would never look there. `release.yml` now copies `integrations/` into the release tarball, because the formula installs out of the tarball and never sees this repository — without that, `pkgshare.install` would fail on every release.

## Manual

A `DEFAULT MARKDOWN VIEWER` section covers both mechanisms, the two terminals that can do this, and the two that cannot — iTerm2, whose Semantic History fires on any Cmd-clicked filename and so needs a dispatch script rather than a fragment, and Terminal.app, which offers nothing to configure.

One trap is documented where it bit: `wezterm.glob` is an async function, so calling it to locate the binary raises *attempt to yield across a C-call boundary* from a module chunk — indistinguishable from mdmost not being installed. The module uses `io.open`.

## Verification

Both packages were built and inspected, not merely reasoned about:

- `dpkg-deb -c` and `rpm2cpio | cpio -t` place every file as intended; the desktop entry is deliberately not marked `doc` in the rpm.
- The **packaged** desktop entry passes `desktop-file-validate` after extraction, and `usr/bin/mdmost` ships in the same package.
- `lintian` reports **no desktop-file tags at all** — in particular not `desktop-command-not-in-package`, the check that `Exec=` resolves to something the package ships.
- The Lua module passes **14 URI cases** in WezTerm's own interpreter, including percent-encoded spaces, an encoded `#` that must survive, `file://localhost/…`, a foreign hostname that must be refused, and `file:///a/b.md/c.txt` which must not match.
- The release tarball layout was simulated: `integrations/` lands where `pkgshare.install` looks.
- 25 config tests pass, including `the_configuration_example_in_the_manual_is_valid` — that test takes the *first* toml block in the manual, so the new section was checked not to shift it.
- `ruby -c` on the formula, YAML parse on the workflow, TOML parse on the manifest.

### Known, pre-existing

`lintian` reports `groff-message … cannot select font 'C'` **7 times, up from 3**. That is pandoc emitting `\f[C]` for code blocks against a groff without that font, so the count scales with how many code blocks the manual has, and this PR adds several. Cosmetic, pre-existing in kind, and fixing it means changing the pandoc invocation for the whole manual — out of scope here.

`no-changelog` and `unstripped-binary-or-object` are also pre-existing and untouched by this change.

## Not tested

The actual mouse click. That needs a GUI window, so the WezTerm and kitty fragments are verified by their matching logic and their syntax rather than end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
