### PR TITLE
Release bump must move Cargo.lock, not just Cargo.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,30 @@ jobs:
 
       - name: Update Cargo.toml version
         run: |
-          sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.version }}"/' Cargo.toml
-          # Keep Cargo.lock's own record of the version in step, so the release commit
-          # is not immediately dirty for anyone who builds it.
-          cargo update --workspace --offline || cargo update -p mdmost --offline || true
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+
+          # Cargo.lock records this package's own version too, so it has to move with
+          # Cargo.toml. If it does not, the release commit is internally inconsistent:
+          # dirty the moment anyone builds it, and fatal at `cargo publish`, which
+          # re-resolves, rewrites Cargo.lock and then refuses to publish a dirty tree.
+          #
+          # Not `--offline`. This job checks out and edits Cargo.toml without ever
+          # fetching the registry, so an offline resolve cannot find a single
+          # dependency and dies with "no matching package named `anyhow` found".
+          # `--workspace` keeps it to the workspace's own entry -- no dependency is
+          # touched, which is what makes running it here safe.
+          #
+          # And no `|| true`. Swallowing the failure is what turned a broken step into
+          # a broken release: v0.1.1 was tagged with Cargo.toml at 0.1.1 and
+          # Cargo.lock still at 0.1.0, and the publish failed 6 minutes later.
+          cargo update --workspace
+
+          # Fail here rather than at the end of the run if the lock did not take.
+          if ! grep -A1 '^name = "mdmost"$' Cargo.lock | grep -qx "version = \"${VERSION}\""; then
+            echo "::error::Cargo.lock does not record version ${VERSION}"
+            exit 1
+          fi
 
       - name: Update CHANGES.md
         run: |
@@ -247,7 +267,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Publish
-        run: cargo publish --token "${{ secrets.CRATES_IO_TOKEN }}"
+        # `--locked` publishes exactly what the tag locked, and turns a stale
+        # Cargo.lock into an error that names the lock rather than into the puzzling
+        # "working directory contains changes that were not yet committed" that comes
+        # from cargo silently rewriting it first.
+        #
+        # The token goes through the environment because `--token` is deprecated.
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --locked
 
   homebrew:
     name: Update Homebrew formula

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@
 
 ### Fixed
 
+- The release no longer tags a commit whose `Cargo.toml` and `Cargo.lock` disagree
+  about the version, which is what stopped `v0.1.1` from reaching crates.io. The
+  version bump refreshed the lock with `cargo update --offline`, but that job never
+  fetches the registry, so the resolve failed on the first dependency it looked up —
+  and a trailing `|| true` swallowed it. `cargo publish` then re-resolved, rewrote
+  `Cargo.lock` itself, and refused to publish a dirty tree. The lock update now runs
+  online, is not allowed to fail quietly, and is checked before the commit is made;
+  `cargo publish --locked` names the lock if it is ever stale again. `Cargo.lock` is
+  brought up to `0.1.1` here, so the tree is consistent again.
+
 ## 0.1.1 - 2026-08-17
 
 ### New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "mdmost"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arboard",


### PR DESCRIPTION
Fixes the failure in [run 32014424039](https://github.com/oetiker/mdmost/actions/runs/32014424039/job/95342240711).

## What happened

`v0.1.1` was tagged with `Cargo.toml` at `0.1.1` and `Cargo.lock` still at `0.1.0`. Six minutes later the publish job died:

```
error: 1 files in the working directory contain changes that were not yet committed into git:

Cargo.lock

to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
```

`cargo publish` re-resolves, notices the lock disagrees with the manifest, **rewrites `Cargo.lock` itself**, and then refuses to publish a tree it has just dirtied. So the error names `Cargo.lock` without saying why it changed.

## Why the lock was stale

The bump step already tried to keep it in step:

```sh
cargo update --workspace --offline || cargo update -p mdmost --offline || true
```

The `version` job checks out and edits `Cargo.toml` without ever fetching the registry, so an offline resolve cannot find a single dependency:

```
error: no matching package named `anyhow` found
location searched: crates.io index
required by package `mdmost v0.1.1`
note: offline mode (via `--offline`) can sometimes cause surprising resolution failures
```

Both attempts failed. **`|| true` swallowed both**, and the release commit went out internally inconsistent — dirty for anyone who builds it, and fatal at publish. That trailing `|| true` is the actual defect: it turned a broken step into a broken release, six jobs downstream from the cause.

## The fix

- **Drop `--offline`.** `--workspace` keeps the update to the workspace's own entry, which is what makes running it online safe here.
- **Drop `|| true`.** A lock that cannot be updated must stop the release.
- **Check the lock took**, before the commit is made, so this fails in the *first* job of the run rather than the last.
- **`cargo publish --locked`**, so a stale lock is reported as a stale lock instead of as an unexplained dirty working directory.
- **Token via `CARGO_REGISTRY_TOKEN`**, since `--token` is deprecated and warns on every run.
- **`Cargo.lock` brought to `0.1.1`**, so `main` is consistent again.

## Verification

- **`cargo update --workspace` changes exactly one line** — `mdmost` `0.1.0` → `0.1.1` — and touches no dependency. That was the risk in dropping `--offline`, so I measured it rather than assumed it.
- **`cargo publish --dry-run --locked` now succeeds** from a clean worktree at this commit: it packages `mdmost v0.1.1`, builds it, and reaches `Uploading` before aborting for the dry run. No dirty tree, no lock complaint.
- **The new guard was tested both ways**: it passes for `0.1.1` and correctly rejects a lock still holding an older version.
- `release.yml` parses as YAML, with the token in `env` and the run reduced to `cargo publish --locked`.

## The v0.1.1 tag is not repaired by this

It cannot be. The tag points at a commit whose lock is stale, so `cargo publish` from `v0.1.1` will always fail, and moving a published tag would orphan the GitHub release artifacts already built from it. crates.io currently has **0.1.0 only**.

Two ways forward, once this is merged:

1. **Cut `v0.1.2`** with the workflow fixed. One `workflow_dispatch`, nothing rewritten, and `0.1.1` is simply a version that never reached crates.io — an unremarkable gap. **This is what I would do.**
2. **Publish `0.1.1` by hand** from merged `main`, whose `Cargo.toml` and `Cargo.lock` now both say `0.1.1`. The uploaded crate would then be `main`-at-merge rather than the `v0.1.1` tag, so the tag and the published crate would not correspond exactly.

Neither is done here — that call is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
