### PR TITLE
Fix a fresh install on macOS, and bare `mdmost` hanging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,3 +324,168 @@ jobs:
           git add Formula/mdmost.rb
           git commit -m "Homebrew formula for ${{ needs.version.outputs.tag }}"
           git push origin main
+
+  # Nothing here is compiled, but a formula with no bottle is a *source build* as far as
+  # Homebrew is concerned, and a source build refuses to run on a Mac whose Command Line
+  # Tools are older than its macOS. Bottling is how that check is skipped.
+  #
+  # This runs after `homebrew` on purpose: it installs the formula from the tap, so the
+  # version and the sha256 lines that job pushed have to be on `main` first.
+  bottles:
+    name: Bottle on ${{ matrix.os }}
+    needs: [version, homebrew]
+    runs-on: ${{ matrix.os }}
+    # Only the leg that is expected to rot is allowed to fail quietly. A missing Intel
+    # bottle is a slow install for Intel Macs; a broken arm64 bottle is a real defect and
+    # fails the release.
+    continue-on-error: ${{ matrix.optional || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The oldest image per architecture, because Homebrew's fallback lets a bottle
+          # serve *newer* macOS and never older. macos-13 is the last Intel image there
+          # is; when GitHub retires it, this leg starts failing and Intel Macs go back to
+          # the source path, which is why it is the optional one.
+          - os: macos-14
+          - os: macos-13
+            optional: true
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Tap and trust
+        # Homebrew 6.0 stopped loading formulae from third-party taps until they are
+        # trusted. `brew trust` does not exist before that, and the `||` keeps this
+        # working on a runner image that is still on Homebrew 5.
+        run: |
+          brew tap oetiker/mdmost https://github.com/oetiker/mdmost
+          brew trust --formula oetiker/mdmost/mdmost || true
+
+      - name: Build the bottle
+        # `--build-bottle` also downloads and checksums the release tarball, so this is
+        # an end-to-end test of the artifacts `create-release` published.
+        run: |
+          brew install --build-bottle oetiker/mdmost/mdmost
+          brew bottle --json --no-rebuild \
+            --root-url="https://github.com/oetiker/mdmost/releases/download/${{ needs.version.outputs.tag }}" \
+            oetiker/mdmost/mdmost
+          ls -la ./*.bottle.*
+
+      - name: Upload bottle
+        uses: actions/upload-artifact@v7
+        with:
+          name: bottle-${{ matrix.os }}
+          path: |
+            ./*.bottle.tar.gz
+            ./*.bottle.json
+
+  publish-bottles:
+    name: Publish bottles
+    needs: [version, bottles]
+    # A skipped or failed `bottles` leg would otherwise skip this job too, and one
+    # architecture is worth publishing on its own. The steps below handle finding no
+    # bottles at all.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Download bottles
+        uses: actions/download-artifact@v8
+        with:
+          path: bottles
+          pattern: bottle-*
+          merge-multiple: true
+
+      - name: Upload bottles to the release
+        # `brew bottle` writes `name--version.tag.bottle.tar.gz`, with two dashes, which
+        # is the name GitHub Packages wants. A plain `root_url` like ours is fetched as
+        # `name-version.tag.bottle.tar.gz`, with one — see `Bottle::Filename#url_encode`
+        # against `#github_packages` in Homebrew. The json carries both names, so the
+        # rename is read from it rather than guessed at.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          shopt -s nullglob
+          jsons=(bottles/*.bottle.json)
+          if [ ${#jsons[@]} -eq 0 ]; then
+            echo "::warning::no bottles were built; the formula keeps an empty bottle block"
+            exit 0
+          fi
+          for json in "${jsons[@]}"; do
+            # One tag per runner in practice, but read them all rather than assume it.
+            jq -r '.[].bottle.tags[] | "\(.local_filename)\t\(.filename)"' "$json" \
+            | while IFS=$'\t' read -r local_name upload_name; do
+                mv "bottles/${local_name}" "bottles/${upload_name}"
+                echo "uploading ${upload_name}"
+                gh release upload "${{ needs.version.outputs.tag }}" \
+                  "bottles/${upload_name}" --clobber
+              done
+          done
+
+      - name: Rewrite the bottle block
+        # Generated rather than patched line by line: which architectures produced a
+        # bottle is not known ahead of time, and a `sha256` line for a bottle that was
+        # never uploaded would send Homebrew after a file that does not exist.
+        run: |
+          shopt -s nullglob
+          jsons=(bottles/*.bottle.json)
+          # Not `[ ... ] && exit 0`: the steps run under `bash -e`, where a false test as
+          # the head of an AND-list fails the step.
+          if [ ${#jsons[@]} -eq 0 ]; then
+            echo "no bottles to write"
+            exit 0
+          fi
+          {
+            echo "  # BOTTLE-START"
+            echo "  bottle do"
+            echo "    root_url \"https://github.com/oetiker/mdmost/releases/download/${{ needs.version.outputs.tag }}\""
+            for json in "${jsons[@]}"; do
+              # `cellar` sits on the bottle, and `brew bottle` copies it onto each tag;
+              # read the tag's own value first and fall back to the bottle's.
+              jq -r '.[].bottle as $b | $b.tags | to_entries[]
+                     | "    sha256 cellar: :\(.value.cellar // $b.cellar), \(.key): \"\(.value.sha256)\""' "$json"
+            done
+            echo "  end"
+            echo "  # BOTTLE-END"
+          } > bottle-block.txt
+          cat bottle-block.txt
+          # The generated block carries its own markers, so it replaces the old range
+          # exactly where that range was. Substituting in place rather than deleting and
+          # re-inserting is what keeps this idempotent: every release rewrites the same
+          # lines instead of drifting the whitespace around them.
+          grep -q '# BOTTLE-START' Formula/mdmost.rb || {
+            echo "::error::the bottle markers are gone from Formula/mdmost.rb"
+            exit 1
+          }
+          awk '
+            /# BOTTLE-START/ {
+              while ((getline line < "bottle-block.txt") > 0) print line
+              inside = 1
+              next
+            }
+            /# BOTTLE-END/ { inside = 0; next }
+            !inside
+          ' Formula/mdmost.rb > Formula/mdmost.rb.new
+          mv Formula/mdmost.rb.new Formula/mdmost.rb
+          cat Formula/mdmost.rb
+
+      - name: Commit
+        run: |
+          if git diff --quiet Formula/mdmost.rb; then
+            echo "no bottle changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/mdmost.rb
+          git commit -m "Homebrew bottles for ${{ needs.version.outputs.tag }}"
+          git push origin main

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,16 @@
 
 ### New
 
+- Releases now ship Homebrew bottles for macOS. Without one, Homebrew treats the
+  formula as a source build even though nothing in it is compiled, and refuses to
+  install on a Mac whose Command Line Tools are older than its macOS. One bottle per
+  architecture covers later macOS releases too.
+
 ### Changed
+
+- The Homebrew instructions now include `brew trust --formula oetiker/mdmost/mdmost`.
+  Homebrew 6.0 stopped loading formulae from third-party taps until they are trusted, so
+  `brew install mdmost` alone no longer finds the formula.
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 
+- `mdmost` with no arguments at a terminal prints its help and exits instead of hanging.
+  It read standard input whenever no file was named, so bare `mdmost` sat waiting on a
+  terminal nobody was typing into, which is indistinguishable from a hang. `mdmost -`
+  still reads standard input on purpose, and `cat x.md | mdmost` is unchanged.
 - The release no longer tags a commit whose `Cargo.toml` and `Cargo.lock` disagree
   about the version, which is what stopped `v0.1.1` from reaching crates.io. The
   version bump refreshed the lock with `cargo update --offline`, but that job never

--- a/Formula/mdmost.rb
+++ b/Formula/mdmost.rb
@@ -12,6 +12,23 @@ class Mdmost < Formula
   version "0.1.1"
   license "MIT"
 
+  # Bottles exist for one reason: without one, Homebrew treats this formula as a source
+  # build and refuses to install on a Mac whose Command Line Tools are older than its
+  # macOS, even though nothing here is compiled. The block is rewritten by
+  # .github/workflows/release.yml once a release's bottles exist, and the marker
+  # comments are the range that rewrite replaces — do not remove them. Empty means no
+  # bottle is published yet, which costs nothing but that check.
+  #
+  # One bottle per architecture is enough: on macOS, Homebrew falls back to a bottle
+  # built for an *older* macOS of the same architecture (find_older_compatible_tag in
+  # extend/os/mac/utils/bottles.rb), so these keep working on later releases. That
+  # fallback only reaches upward, which is why the bottles are built on the oldest
+  # runner image available for each architecture.
+  # BOTTLE-START
+  bottle do
+  end
+  # BOTTLE-END
+
   on_macos do
     on_arm do
       url "https://github.com/oetiker/mdmost/releases/download/v#{version}/mdmost-#{version}-aarch64-apple-darwin.tar.gz"

--- a/README.md
+++ b/README.md
@@ -19,23 +19,6 @@ brew trust --formula oetiker/mdmost/mdmost
 brew install mdmost
 ```
 
-Homebrew 6.0 stopped loading formulae from third-party taps until they are trusted, so
-the middle line is required. It trusts this one formula rather than the whole tap.
-`brew install oetiker/mdmost/mdmost` does the same thing in one step, because a
-fully-qualified name trusts the formula it names. On Homebrew 5 and older there is no
-`brew trust` command and no trust to grant: skip that line.
-
-On **macOS**, `brew install` may stop with *Your Command Line Tools are too outdated*.
-The formula ships prebuilt binaries and compiles nothing, but Homebrew calls any install
-without a matching bottle a source build, and a source build insists on working developer
-tools. Releases ship bottles for current macOS, so this only comes up on a Mac older than
-those bottles. The commands Homebrew prints are the fix:
-
-```sh
-sudo rm -rf /Library/Developer/CommandLineTools
-sudo xcode-select --install
-```
-
 **Debian, Ubuntu** — download `mdmost_<version>_amd64.deb` (or `_arm64.deb`) from the
 [releases page](https://github.com/oetiker/mdmost/releases):
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ than on Unix.
 
 ```sh
 mdmost README.md              # open a document
-mdmost                        # read standard input
+mdmost -                      # read standard input
 cat notes.md | mdmost         # same, keyboard still works
 export PAGER=mdmost           # use it as your pager
 mdmost --mouse README.md      # wheel, drag-to-copy, clickable links
@@ -72,7 +72,8 @@ Two rules make the pipe cases work. When the input is a pipe, the keyboard is re
 `/dev/tty`, so `cat x.md | mdmost` stays interactive. When *stdout* is not a terminal,
 `--render-once` is implied, so `mdmost x.md | cat` produces plain text instead of escape
 sequences. `mdmost --render-once --width 80 doc.md` is therefore usable for scripting and
-snapshotting.
+snapshotting. Bare `mdmost` at a prompt has no document coming, so it prints its help
+instead of waiting on a terminal nobody is typing into.
 
 Every flag is in the
 [manual](https://github.com/oetiker/mdmost/blob/main/docs/manual.md#options), or in

--- a/README.md
+++ b/README.md
@@ -15,7 +15,25 @@ A full-screen terminal pager for one Markdown document
 
 ```sh
 brew tap oetiker/mdmost https://github.com/oetiker/mdmost
+brew trust --formula oetiker/mdmost/mdmost
 brew install mdmost
+```
+
+Homebrew 6.0 stopped loading formulae from third-party taps until they are trusted, so
+the middle line is required. It trusts this one formula rather than the whole tap.
+`brew install oetiker/mdmost/mdmost` does the same thing in one step, because a
+fully-qualified name trusts the formula it names. On Homebrew 5 and older there is no
+`brew trust` command and no trust to grant: skip that line.
+
+On **macOS**, `brew install` may stop with *Your Command Line Tools are too outdated*.
+The formula ships prebuilt binaries and compiles nothing, but Homebrew calls any install
+without a matching bottle a source build, and a source build insists on working developer
+tools. Releases ship bottles for current macOS, so this only comes up on a Mac older than
+those bottles. The commands Homebrew prints are the fix:
+
+```sh
+sudo rm -rf /Library/Developer/CommandLineTools
+sudo xcode-select --install
 ```
 
 **Debian, Ubuntu** — download `mdmost_<version>_amd64.deb` (or `_arm64.deb`) from the

--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -230,6 +230,42 @@ Things worth knowing before you go hunting:
   names are compared verbatim, so keep the wording identical. That test cannot see the
   TUI chrome; the Arrows line in that section is maintained by hand.
 
+## Homebrew bottles exist to dodge the compiler check
+
+Nothing in the formula is compiled: it unpacks a release tarball. But Homebrew calls any
+install with no matching bottle a **source build**, and a source build runs
+`fatal_build_from_source_checks`, which aborts with *Your Command Line Tools are too
+outdated* on a Mac whose CLT is older than its macOS. `bottle :unneeded`, which used to
+say "no compiler needed", was removed in Homebrew 3.0. A bottle is the only way left.
+
+Four things to know before touching `.github/workflows/release.yml`:
+
+- **One bottle per architecture is enough.** `find_older_compatible_tag` in Homebrew's
+  `extend/os/mac/utils/bottles.rb` accepts a bottle built for an *older or equal* macOS of
+  the same architecture. The fallback only reaches upward, so bottles are built on the
+  oldest runner image per architecture: `macos-14` for arm64, `macos-13` for Intel.
+  `macos-13` is the last Intel image GitHub has; that leg is `continue-on-error` because it
+  will eventually vanish, and when it does Intel Macs simply go back to the source path.
+- **The filename is renamed on upload.** `brew bottle` writes
+  `mdmost--<version>.<tag>.bottle.tar.gz`, with two dashes, which is what GitHub Packages
+  wants. A plain `root_url` like ours is fetched as `mdmost-<version>.<tag>.bottle.tar.gz`,
+  with one. Compare `Bottle::Filename#url_encode` with `#github_packages`. Both names are
+  in the `--json` output as `filename` and `local_filename`, so the workflow reads them
+  rather than constructing either.
+- **The `bottle do` block is generated, not patched.** Which architectures produced a
+  bottle is not known ahead of time, and a `sha256` line for a bottle that was never
+  uploaded sends Homebrew after a file that is not there. The generated block carries its
+  own `# BOTTLE-START` / `# BOTTLE-END` markers and replaces that range in place, which is
+  what keeps the rewrite idempotent. Removing those markers fails the job by design.
+- **`bottles` runs after `homebrew`, not beside it.** It installs from the tap, so the
+  version and the four url `sha256` lines have to be on `main` first. As a side effect
+  `brew install --build-bottle` checksums the published tarball, so this doubles as an
+  end-to-end test of what `create-release` uploaded.
+
+Homebrew 6.0 also stopped loading formulae from untrusted third-party taps, so CI taps and
+then runs `brew trust --formula oetiker/mdmost/mdmost`. The `|| true` after it is for a
+runner image still on Homebrew 5, where the command does not exist.
+
 ## Regenerating the demo
 
 `docs/demo/mdmost.webp` is the README's hero image. It is recorded with

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -26,7 +26,9 @@ everything reflows and the same table is drawn dense in a wide terminal and
 spaced in a narrow one.
 
 With no *FILE*, the document is read from standard input and the keyboard is read
-from */dev/tty*, so `cat notes.md | mdmost` stays interactive. When standard
+from */dev/tty*, so `cat notes.md | mdmost` stays interactive. When standard input
+is a terminal there is no document on the way, so **mdmost** prints its help and
+exits rather than waiting; pass `-` to read from a terminal anyway. When standard
 output is not a terminal, `--render-once` is implied, so `mdmost doc.md | cat`
 writes plain text rather than escape sequences.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::io::{self, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 
 use mdmost::config::Config;
 use mdmost::doc::Doc;
@@ -35,7 +35,7 @@ const FALLBACK_WIDTH: u16 = 80;
 #[derive(Debug, Parser)]
 #[command(name = "mdmost", version, about, long_about = None)]
 struct Cli {
-    /// The document to show. Omit it, or pass `-`, to read standard input.
+    /// The document to show. Pass `-`, or pipe one in, to read standard input.
     file: Option<PathBuf>,
 
     /// Render one frame to standard output and exit. Needs no terminal.
@@ -194,6 +194,14 @@ fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         return Ok(ExitCode::from(EXIT_USAGE));
     }
 
+    // Before the config file is touched, because this path answers a question about the
+    // program rather than showing a document.
+    let input = input_source(cli.file.as_deref(), io::stdin().is_terminal());
+    if input == Input::Nothing {
+        Cli::command().print_help()?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
     let loaded = match &cli.config {
         Some(path) => Config::load_from(path),
         None => Config::load(),
@@ -207,7 +215,11 @@ fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         return Ok(ExitCode::from(EXIT_USAGE));
     }
 
-    let (source, title) = match read_input(cli.file.as_deref()) {
+    let (source, title) = match read_input(match input {
+        Input::File(path) => Some(path),
+        // `Nothing` returned above, so this is standard input either way.
+        Input::Stdin | Input::Nothing => None,
+    }) {
         Ok(pair) => pair,
         Err(error) => {
             let _ = writeln!(io::stderr(), "mdmost: {error}");
@@ -336,13 +348,41 @@ fn render_once(
     Ok(ExitCode::SUCCESS)
 }
 
+/// Where the document is to come from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Input<'a> {
+    /// A file named on the command line.
+    File(&'a Path),
+    /// Standard input, because it was piped in or because `-` asked for it.
+    Stdin,
+    /// Nothing at all: no file, and standard input is the terminal the reader is
+    /// sitting at. There is no document on the way and waiting for one looks like a
+    /// hang, so bare `mdmost` is taken as a question about the program.
+    Nothing,
+}
+
+/// What the arguments and the state of standard input say to read.
+///
+/// Split out from [`read_input`] because the interesting case is the one the test
+/// suite cannot stage: integration tests run with pipes on both ends, so standard
+/// input is never a terminal there.
+fn input_source(file: Option<&Path>, stdin_is_terminal: bool) -> Input<'_> {
+    match file {
+        // `-` is a request, not a default. Someone who types it at a terminal means
+        // it, and `mdmost --licenses | mdmost -` relies on it.
+        Some(path) if path.as_os_str() == "-" => Input::Stdin,
+        Some(path) => Input::File(path),
+        None if stdin_is_terminal => Input::Nothing,
+        None => Input::Stdin,
+    }
+}
+
 /// Reads the document and works out what to call it in the status bar.
+///
+/// `None` is standard input; [`input_source`] has already decided that it is the right
+/// place to read from.
 fn read_input(file: Option<&Path>) -> Result<(String, String), mdmost::Error> {
-    let from_stdin = match file {
-        None => true,
-        Some(path) => path.as_os_str() == "-",
-    };
-    if from_stdin {
+    if file.is_none() {
         let mut source = String::new();
         io::stdin()
             .read_to_string(&mut source)
@@ -362,4 +402,44 @@ fn read_input(file: Option<&Path>) -> Result<(String, String), mdmost::Error> {
         .map(|name| name.to_string_lossy().into_owned())
         .unwrap_or_else(|| path.display().to_string());
     Ok((source, title))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Input, input_source};
+    use std::path::Path;
+
+    #[test]
+    fn a_named_file_is_read_whatever_standard_input_is() {
+        let path = Path::new("notes.md");
+        for stdin_is_terminal in [true, false] {
+            assert_eq!(
+                input_source(Some(path), stdin_is_terminal),
+                Input::File(path)
+            );
+        }
+    }
+
+    #[test]
+    fn a_pipe_with_no_file_is_standard_input() {
+        assert_eq!(input_source(None, false), Input::Stdin);
+    }
+
+    #[test]
+    fn nothing_at_all_is_neither_a_document_nor_a_wait() {
+        // The bug this guards: bare `mdmost` at a prompt used to block in
+        // `read_to_string` on a terminal nobody was typing into, which is
+        // indistinguishable from a hang.
+        assert_eq!(input_source(None, true), Input::Nothing);
+    }
+
+    #[test]
+    fn a_dash_asks_for_standard_input_even_at_a_terminal() {
+        // `mdmost --licenses | mdmost -` is documented, and someone who types the dash
+        // has said what they want; only the *absence* of an argument is ambiguous.
+        let dash = Path::new("-");
+        for stdin_is_terminal in [true, false] {
+            assert_eq!(input_source(Some(dash), stdin_is_terminal), Input::Stdin);
+        }
+    }
 }


### PR DESCRIPTION
Three problems found by installing on a Mac with Homebrew, plus the hang that turned up alongside them.

## `brew install` could not find the formula

Homebrew 6.0 (2026-06-11) stopped loading formulae from third-party taps until they are trusted, so `brew tap` followed by `brew install mdmost` no longer works. The README now says:

```sh
brew tap oetiker/mdmost https://github.com/oetiker/mdmost
brew trust --formula oetiker/mdmost/mdmost
brew install mdmost
```

Per-formula rather than whole-tap, which is what [Tap Trust](https://docs.brew.sh/Tap-Trust) recommends. `brew install oetiker/mdmost/mdmost` does it in one step, since a fully-qualified name trusts what it names. Homebrew 5 and older have no `brew trust` and need no trust, so that line is skipped there.

## `Your Command Line Tools are too outdated`

Nothing in the formula is compiled, but Homebrew calls an install with **no matching bottle** a source build, and a source build runs the fatal developer-tools checks. `bottle :unneeded`, which used to declare "no compiler needed", was removed in Homebrew 3.0. A bottle is the only remaining fix.

`release.yml` grows two jobs:

- **`bottles`** — builds on `macos-14` and `macos-13`, after `homebrew` has pushed the version and url checksums to `main`, because it installs from the tap. `--build-bottle` also downloads and checksums the published tarball, so this doubles as an end-to-end test of what `create-release` uploaded.
- **`publish-bottles`** — uploads the bottles to the release and rewrites the formula's `bottle do` block.

Three details are load-bearing, and all three were checked against Homebrew's source rather than recalled:

| Detail | Where it comes from |
|---|---|
| One bottle per architecture is enough; it serves **newer** macOS but never older, hence the oldest runner image per architecture | `find_older_compatible_tag`, `extend/os/mac/utils/bottles.rb` |
| `brew bottle` writes `name--version.tag` (GitHub Packages), but a plain `root_url` is fetched as `name-version.tag`, so the file is renamed on upload | `Bottle::Filename#url_encode` vs `#github_packages` |
| `--no-rebuild` is a real flag | `dev-cmd/bottle.rb` |

`macos-13` is the last Intel image GitHub has, so that leg is `continue-on-error`. When it goes away, Intel Macs return to the source path and the release still passes.

The `bottle do` block is **generated, not patched line by line**: which architectures produced a bottle is not known ahead of time, and a `sha256` line for a bottle that was never uploaded sends Homebrew after a file that does not exist. The generated block carries its own markers and replaces that range in place, which keeps the rewrite idempotent.

## Bare `mdmost` hung instead of printing help

`read_input` read standard input whenever no file was named, so `mdmost` at a prompt blocked in `read_to_string` on a terminal nobody was typing into — indistinguishable from a hang.

The decision moved into `input_source`, which is pure so it can be tested: the integration tests run with pipes on both ends, so standard input is never a terminal there and the interesting case cannot be staged.

| Arguments | stdin | Result |
|---|---|---|
| `notes.md` | either | read the file |
| none | pipe | read stdin, as before |
| none | **terminal** | print help, exit 0 |
| `-` | either | read stdin |

`-` keeps working on purpose: `mdmost --licenses \| mdmost -` is documented, and someone who types the dash has said what they mean. Only the absence of an argument was ambiguous.

## What was verified, and what was not

Verified locally: `cargo fmt --check`, `clippy --all-targets -D warnings`, the full suite (906 lib tests plus every integration suite, 0 failures) including 4 new unit tests for `input_source`, and the hang fix exercised for real under a pty with `script -qec`. Every `run:` script in the workflow passes `bash -n`. The two new workflow steps were extracted from the YAML and executed against fixture JSON, covering the rename and upload loop, block generation with the per-tag `cellar` fallback, a splice that is valid Ruby and byte-identical across three passes, the missing-marker guard failing loudly, and the no-bottles-at-all path exiting 0 and leaving the formula untouched.

**Not verified, and it cannot be from a Linux box: whether `brew install --build-bottle` and `brew bottle` succeed on a real runner.** That needs one real release to prove. Two specific unknowns:

- Whether `macos-13` still exists. If GitHub has retired it, that leg fails, `continue-on-error` absorbs it, and you will see a red leg inside a green workflow.
- `Homebrew/actions/setup-homebrew@master` is unpinned, unlike the `@v7`/`@v8` pins elsewhere in this workflow. That is what Homebrew's own documentation specifies, but it is a moving target.

The mechanics are written up in `docs/maintainer-notes.md` under *Homebrew bottles exist to dodge the compiler check*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)