### PR TITLE
ci: build the Intel bottle on macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,17 +338,33 @@ jobs:
     # Only the leg that is expected to rot is allowed to fail quietly. A missing Intel
     # bottle is a slow install for Intel Macs; a broken arm64 bottle is a real defect and
     # fails the release.
+    #
+    # `continue-on-error` covers a leg that *runs* and fails. It does nothing for a leg
+    # that never starts, and that is the failure these labels actually have: a retired
+    # image leaves the job **queued** with no runner for the 24 hours GitHub waits before
+    # cancelling it, `publish-bottles` never fans in, and the bottle the other leg built
+    # in half a minute is left in an artifact nobody collects. That is what happened to
+    # v0.1.2, which shipped with an empty bottle block. Nothing in the workflow can catch
+    # it — `timeout-minutes` bounds run time, not queue time — so the labels below have
+    # to be kept current by hand, and a release that sits in `queued` is the symptom.
     continue-on-error: ${{ matrix.optional || false }}
     strategy:
       fail-fast: false
       matrix:
         include:
           # The oldest image per architecture, because Homebrew's fallback lets a bottle
-          # serve *newer* macOS and never older. macos-13 is the last Intel image there
-          # is; when GitHub retires it, this leg starts failing and Intel Macs go back to
-          # the source path, which is why it is the optional one.
+          # serve *newer* macOS and never older.
+          #
+          # macos-14 is arm64 and is now deprecated; it still schedules, and moving up to
+          # macos-15 would narrow the bottle to Sequoia and later, so it stays until it
+          # stops working. macos-15-intel is the last x86_64 image GitHub will ever
+          # offer — a standard runner, not a paid larger one — and it goes away in August
+          # 2027 along with Intel support altogether. Being macOS 15, its bottle serves
+          # Sequoia and later only: an Intel Mac on Ventura or Sonoma gets the source
+          # path, and there is no older Intel runner left to change that. It is the
+          # optional leg for that reason.
           - os: macos-14
-          - os: macos-13
+          - os: macos-15-intel
             optional: true
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,14 @@
   now no inline style carries a background at all. Bold link text also keeps the link
   colour instead of reverting to body ink.
 
+- The release workflow builds its Intel bottle on `macos-15-intel`. It asked for
+  `macos-13`, which GitHub retired in December 2025, and a retired image does not fail a
+  job — it leaves it queued for the 24 hours GitHub waits before cancelling it. The
+  bottle-publishing step waits on the whole matrix, so nothing was published at all:
+  v0.1.2 shipped with an empty bottle block and no bottles on the release, despite the
+  arm64 one having built successfully. Intel bottles now cover macOS 15 and later, which
+  is as far back as the last Intel runner image reaches.
+
 ## 0.1.2 - 2026-08-18
 
 ### New


### PR DESCRIPTION
`macos-13` is retired, and it does not fail the way this workflow assumed it would.

## What happened

Run [32105096523](https://github.com/oetiker/mdmost/actions/runs/32105096523), the v0.1.2 release. Every job passed except `Bottle on macos-13`, which was **queued with no runner** — 6.5 hours when I looked, and GitHub only cancels a queued job at the 24-hour mark. GitHub [retired the macOS 13 image](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/) on 4 December 2025.

The comment in the workflow predicted "this leg starts failing and Intel Macs go back to the source path". It does not start failing. `continue-on-error` covers a leg that *runs* and fails; it does nothing for one that never starts. So the matrix never completed, `publish-bottles` never fanned in, and the arm64 bottle that built in 27 seconds sat in an artifact nobody collected:

```
$ gh release view v0.1.2 --json assets    # no *.bottle.tar.gz
$ sed -n '/BOTTLE-START/,/BOTTLE-END/p' Formula/mdmost.rb
  bottle do
  end
```

**v0.1.2 shipped with no bottles at all** — the release whose reason for existing was bottles. The stuck run is now cancelled.

## The fix

`macos-13` → `macos-15-intel`. It is a standard runner, not a paid larger one, and it is the [last x86_64 image GitHub will offer](https://github.com/actions/runner-images/issues/13045): it and Intel macOS support both end in August 2027.

One honest limitation: being macOS 15, its bottle is a `sequoia` bottle, and Homebrew's fallback only reaches *upward*. Intel Macs on Ventura or Sonoma still take the source path. No older Intel runner exists to change that, which is why this stays the optional leg.

arm64 stays on `macos-14`. That label is deprecated now as well, but it still schedules, and moving up to `macos-15` would narrow the arm64 bottle to Sequoia and later for no gain today.

## What is not fixed

Nothing in the workflow can catch the next retirement automatically — `timeout-minutes` bounds run time, not queue time, and there is no API for "does this hosted label still exist". Per the decision to keep one workflow rather than split bottling out, the labels are maintained by hand; the comment above the matrix now says what the symptom looks like, so a release sitting in `queued` is recognisable rather than mysterious.

v0.1.2 is left as a source install for everyone; the first working bottles will ride on 0.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)