### PR TITLE
fix(tui): measure how wide this terminal draws an emoji sequence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,18 @@ minor bump rather than a patch.
 
 ### Fixed
 
+- A terminal that draws an emoji-presentation sequence such as `☸️` (a narrow character
+  plus `U+FE0F`) in one column no longer leaves stale characters strewn across the screen
+  when the document is scrolled. The standard makes such a sequence two columns wide,
+  `unicode-width` and `ratatui` both measure two, and a terminal that advances by one is
+  then one column out for the whole run of cells it was handed — which is why the damage
+  spread well beyond the line the emoji was on. mdmost now asks the terminal at startup
+  how wide it draws one, and on a clear answer of one column drops the selector, which
+  draws the same glyph there and puts every measurement back on one number. `narrow_emoji`
+  in the configuration file and `--narrow-emoji` / `--wide-emoji` settle it without
+  measuring. `Config` gained the field, which is an API break for a caller building one
+  by struct literal.
+
 - A Mermaid diagram's degraded-code caption is no longer corrupted where the
   line-number gutter's bottom-edge junction crosses it — "not a diagram type" no
   longer comes out "no┴ a diagram type". This shipped in v0.2.0 for every caption long

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ starting: the problem is reported and the rest of the file still applies.
 ```toml
 theme        = "dark"    # name of a built-in or a [themes.*] table
 line_numbers = false     # line-number gutter in fenced code blocks
+narrow_emoji = false     # emoji-presentation sequences in one column; omit to measure
 mouse        = false     # wheel, drag-to-copy, and [copy] buttons
 body_width   = 72        # widest the prose body is laid out; 0 for no cap
 section_numbers = true   # number headings when a document nests three levels or more

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -64,6 +64,13 @@ writes plain text rather than escape sequences.
 - **`--no-math-backslash`** — Do not read `\(…\)` and `\[…\]`, even if the configuration
   file does.
 
+- **`--narrow-emoji`** — Draw an emoji whose form is set by a variation selector
+  (`U+FE0F`) in one column rather than two, for a terminal that does the same. Left to
+  itself **mdmost** measures the terminal; see *Emoji width* below.
+
+- **`--wide-emoji`** — Draw such an emoji at the width the standard gives it, without
+  measuring the terminal.
+
 - **`--mouse`** — Capture the mouse: the wheel scrolls, the scrollbar drags, a click in
   the contents pane jumps, and a drag over the document copies the Markdown source
   behind it.
@@ -247,6 +254,28 @@ becomes `copied`.
 Capturing the mouse takes away the terminal's own drag-select for as long as
 **mdmost** runs.
 
+## Emoji width
+
+`U+FE0F` asks for the emoji form of a character that also has a text form — `☸️` is
+`☸` plus that selector — and the standard makes the result two columns wide.
+Several terminals draw it in one and move the cursor by one. Nothing can be
+patched over that afterwards: the width tables say two, and so does the library
+that paints the screen, so on such a terminal every line containing one is drawn
+one column out from there on, and scrolling leaves stale characters behind.
+
+**mdmost** therefore asks the terminal at startup: it draws the sequence at the
+start of a line, reads back where the cursor ended up, and erases what it drew.
+A clear answer of one column makes it drop the selector for the rest of the
+session, which draws the same glyph on such a terminal and puts every
+measurement back on one number. Any other answer — including no answer — leaves
+the document exactly as it is.
+
+The question is not put at all when there is no terminal on both standard input
+and standard output, or when `TERM` is unset, `dumb` or `linux`. To settle it
+without being asked, write `narrow_emoji = true` (or `false`) in the
+configuration file, or pass `--narrow-emoji` / `--wide-emoji`; a flag is saved by
+`S`, a measurement never is.
+
 # CONFIGURATION
 
 The configuration file is TOML, at *~/.config/mdmost/config.toml*, or in the
@@ -263,6 +292,7 @@ icons        = true      # Nerd Font glyphs; false is plain Unicode; omit to det
 line_numbers = false     # line-number gutter in fenced code blocks
 title_banner = false     # off; true sets a lone `#` title as a wrapped FIGlet banner
 section_numbers = true   # number headings when a document nests three levels or more
+narrow_emoji = false     # emoji-presentation sequences in one column; omit to measure
 mouse        = false     # wheel scrolls, scrollbar drags, TOC clicks jump, drag copies
                          # source, and code frames and tables get a [copy] button
 scroll_step  = 3         # document lines per mouse-wheel notch

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,6 +144,19 @@ pub struct Config {
     /// agree about. `less` does not capture either. Turn it on with `--mouse` or
     /// `mouse = true`.
     pub mouse: bool,
+    /// Whether this terminal draws an emoji-presentation sequence in one column.
+    ///
+    /// `U+FE0F` asks for the emoji form of a character that also has a text form, and
+    /// the standard makes the result two columns wide. Several terminals draw it in one.
+    /// Nothing can reconcile that after the fact — `unicode-width` and `ratatui` both
+    /// measure two — so `true` drops the selector instead, which draws the same glyph on
+    /// such a terminal and puts every measurement back on one number (see
+    /// [`crate::text::narrow_emoji`]).
+    ///
+    /// Tri-state like [`Config::icons`], and for the same reason: `None` — the default —
+    /// means nobody has said, and the answer is measured from the terminal at startup.
+    /// `--narrow-emoji` / `--wide-emoji` override even a value written in the file.
+    pub narrow_emoji: Option<bool>,
     /// How many document lines one mouse-wheel notch scrolls.
     pub scroll_step: u16,
     /// The widest the document body is laid out, however wide the terminal is.
@@ -176,6 +189,7 @@ impl Default for Config {
             toc_open: false,
             toc_width: DEFAULT_TOC_WIDTH,
             mouse: false,
+            narrow_emoji: None,
             scroll_step: 3,
             body_width: Some(DEFAULT_BODY_WIDTH),
             keys: KeyBindings::defaults(),
@@ -350,6 +364,7 @@ struct RawConfig {
     title_banner: Option<bool>,
     section_numbers: Option<bool>,
     mouse: Option<bool>,
+    narrow_emoji: Option<bool>,
     scroll_step: Option<u16>,
     body_width: Option<u16>,
     #[serde(default)]
@@ -398,10 +413,11 @@ impl RawConfig {
     /// Validates the raw file into a [`Config`], collecting per-entry problems.
     fn into_config(self, text: &str, path: &Path, problems: &mut Vec<ConfigError>) -> Config {
         let mut config = Config {
-            // Carried straight across as an `Option`, unlike every setting below it: an
-            // absent `icons` key must stay absent so it reaches detection, rather than
-            // being resolved here to a fixed answer.
+            // Carried straight across as an `Option`, unlike every setting below them:
+            // an absent `icons` or `narrow_emoji` key must stay absent so it reaches
+            // detection, rather than being resolved here to a fixed answer.
             icons: self.icons,
+            narrow_emoji: self.narrow_emoji,
             ..Config::default()
         };
 
@@ -627,6 +643,7 @@ const KNOWN_KEYS: &[&str] = &[
     "title_banner",
     "section_numbers",
     "mouse",
+    "narrow_emoji",
     "scroll_step",
     "body_width",
     "toc",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -534,3 +534,17 @@ fn a_misspelt_math_key_is_reported_and_dropped() {
     let loaded = Config::parse_str("mathinline = true\n", path());
     assert_eq!(loaded.problems.len(), 1, "{:?}", loaded.problems);
 }
+
+#[test]
+fn the_emoji_width_answer_is_kept_tri_state() {
+    // Unset means nobody has said, and the answer is measured from the terminal — the
+    // same shape as `icons`, and for the same reason: `Some(false)` and "unset" behave
+    // alike today, but only the first must keep behaving that way on a terminal where
+    // the measurement would say otherwise.
+    assert_eq!(Config::default().narrow_emoji, None);
+    assert_eq!(Config::parse_str("", path()).config.narrow_emoji, None);
+
+    let loaded = Config::parse_str("narrow_emoji = true\n", path());
+    assert!(loaded.problems.is_empty(), "{:?}", loaded.problems);
+    assert_eq!(loaded.config.narrow_emoji, Some(true));
+}

--- a/src/config/write.rs
+++ b/src/config/write.rs
@@ -135,6 +135,15 @@ impl Config {
             },
             Entry {
                 section: None,
+                // Unset for the same reason `icons` is: nobody has said, so the answer
+                // is measured from the terminal, and writing a measurement down would
+                // freeze it for a terminal that later behaves differently. A command
+                // line that *did* say is recorded by `main` before the pager starts.
+                key: "narrow_emoji",
+                value: self.narrow_emoji.map(|narrow| narrow.to_string()),
+            },
+            Entry {
+                section: None,
                 key: "scroll_step",
                 value: Some(self.scroll_step.to_string()),
             },
@@ -211,6 +220,9 @@ impl Config {
         }
         if back.mouse != self.mouse {
             return refuse("mouse");
+        }
+        if back.narrow_emoji != self.narrow_emoji {
+            return refuse("narrow_emoji");
         }
         if back.scroll_step != self.scroll_step {
             return refuse("scroll_step");

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,18 @@ struct Cli {
     #[arg(long, conflicts_with = "math_backslash")]
     no_math_backslash: bool,
 
+    /// Draw emoji whose form is set by a variation selector in one column, not two.
+    ///
+    /// For a terminal that ignores `U+FE0F` and advances the cursor by one where the
+    /// standard says two. Left to itself mdmost measures the terminal and only acts on a
+    /// clear answer; this settles it without asking, and is saved by `S`.
+    #[arg(long)]
+    narrow_emoji: bool,
+
+    /// Draw emoji at the width the standard gives them, without measuring the terminal.
+    #[arg(long, conflicts_with = "narrow_emoji")]
+    wide_emoji: bool,
+
     /// Capture the mouse: wheel scrolls, the scrollbar drags, clicks jump in the contents
     /// pane, and dragging over the document copies the Markdown source behind it.
     ///
@@ -177,6 +189,38 @@ fn resolve_icons(cli: &Cli, configured: Option<bool>) -> bool {
         return from_env;
     }
     configured.unwrap_or_else(mdmost::nerdfont::detect)
+}
+
+/// Whether an emoji-presentation sequence is to be drawn in one column.
+///
+/// A flag settles it, then the configuration file, and only then is the terminal asked —
+/// `measure` is not called at all when anybody has already answered, because asking
+/// writes to the terminal and waits for a reply.
+///
+/// The measurement is believed only when it is unambiguous. Stripping a selector on a
+/// terminal that honours it would make the document worse, so silence, an impossible
+/// answer and the standard two columns all leave it alone. See
+/// [`mdmost::tui::emoji_columns`] for what is asked and when.
+fn resolve_narrow_emoji(
+    narrow: bool,
+    wide: bool,
+    configured: Option<bool>,
+    measure: impl FnOnce() -> Option<u16>,
+) -> bool {
+    debug_assert!(
+        !(narrow && wide),
+        "clap's conflicts_with should make this unreachable"
+    );
+    if narrow {
+        return true;
+    }
+    if wide {
+        return false;
+    }
+    if let Some(answer) = configured {
+        return answer;
+    }
+    measure() == Some(1)
 }
 
 /// A flag pair overriding a configured boolean: either flag wins over the file, and
@@ -277,6 +321,26 @@ fn run(cli: Cli) -> anyhow::Result<ExitCode> {
         cli.no_math_backslash,
         config.math_backslash,
     );
+
+    let narrow_emoji = resolve_narrow_emoji(
+        cli.narrow_emoji,
+        cli.wide_emoji,
+        config.narrow_emoji,
+        mdmost::tui::emoji_columns,
+    );
+    // An answer that came from the command line is a statement the reader made, and `S`
+    // should keep it. A measurement is not written down, for the reason `icons` is not:
+    // it is this terminal's answer, not this reader's.
+    if cli.narrow_emoji || cli.wide_emoji {
+        config.narrow_emoji = Some(narrow_emoji);
+    }
+    // Before the parser, so that every measurement downstream — wrapping, table columns,
+    // the canvas, `ratatui`'s own diff — is taken from text all of them agree about.
+    let source = if narrow_emoji {
+        mdmost::text::narrow_emoji(&source).into_owned()
+    } else {
+        source
+    };
 
     let doc = Doc::parse_auto_with(
         &source,
@@ -465,7 +529,7 @@ fn read_input(file: Option<&Path>) -> Result<(String, String), mdmost::Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Input, input_source, resolve_flag};
+    use super::{Input, input_source, resolve_flag, resolve_narrow_emoji};
     use std::path::Path;
 
     #[test]
@@ -500,6 +564,34 @@ mod tests {
         for stdin_is_terminal in [true, false] {
             assert_eq!(input_source(Some(dash), stdin_is_terminal), Input::Stdin);
         }
+    }
+
+    #[test]
+    fn a_flag_settles_the_emoji_width_without_asking_the_terminal() {
+        // The measurement is not merely overridden but never made: it writes to the
+        // terminal and waits for a reply, and someone who has already answered should
+        // not pay for that.
+        let never = || panic!("the terminal must not be asked");
+        assert!(resolve_narrow_emoji(true, false, None, never));
+        assert!(!resolve_narrow_emoji(false, true, Some(true), never));
+    }
+
+    #[test]
+    fn a_written_answer_is_taken_when_no_flag_says_otherwise() {
+        let never = || panic!("the terminal must not be asked");
+        assert!(resolve_narrow_emoji(false, false, Some(true), never));
+        assert!(!resolve_narrow_emoji(false, false, Some(false), never));
+    }
+
+    #[test]
+    fn only_a_clear_one_column_measurement_narrows_anything() {
+        // Lopsided on purpose, as detection is everywhere in this program: stripping a
+        // selector on a terminal that wanted it is the worse mistake, so silence, a
+        // nonsense reply and the standard answer all leave the document alone.
+        assert!(resolve_narrow_emoji(false, false, None, || Some(1)));
+        assert!(!resolve_narrow_emoji(false, false, None, || Some(2)));
+        assert!(!resolve_narrow_emoji(false, false, None, || Some(0)));
+        assert!(!resolve_narrow_emoji(false, false, None, || None));
     }
 
     #[test]

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -52,6 +52,57 @@ pub fn display_width(text: &str) -> usize {
     text.width()
 }
 
+/// `text` with the emoji-presentation selector dropped where a terminal ignores it.
+///
+/// `U+FE0F` asks for the emoji form of a character that has a text form as well, and
+/// the standard makes the result two columns wide. Several terminals draw it in one
+/// and advance the cursor by one, which is a disagreement no width table can settle:
+/// `unicode-width` says two, `ratatui` skips the second cell on that authority, and
+/// the terminal is then one column out for the rest of everything it was handed —
+/// leaving stale glyphs behind wherever the frame was updated in place.
+///
+/// Dropping the selector is what puts all three back on one number. The pixels do not
+/// change on a terminal that was ignoring the selector; on one that honours it, this
+/// is never applied (see `Config::narrow_emoji`).
+///
+/// Only a lone base character followed by the selector is touched, and only when the
+/// selector is what made it wide. A ZWJ sequence is several emoji glued together, and
+/// taking a selector out of the middle of one would change which glyph is drawn rather
+/// than how wide it is.
+pub fn narrow_emoji(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text.contains(EMOJI_PRESENTATION) {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut dropped = false;
+    for cluster in graphemes(text) {
+        match narrowed(cluster) {
+            Some(base) => {
+                out.push_str(base);
+                dropped = true;
+            }
+            None => out.push_str(cluster),
+        }
+    }
+    if dropped {
+        std::borrow::Cow::Owned(out)
+    } else {
+        std::borrow::Cow::Borrowed(text)
+    }
+}
+
+/// The variation selector that asks for the emoji form.
+const EMOJI_PRESENTATION: char = '\u{FE0F}';
+
+/// The base of `cluster`, when the selector is the only reason it is two columns wide.
+fn narrowed(cluster: &str) -> Option<&str> {
+    let base = cluster.strip_suffix(EMOJI_PRESENTATION)?;
+    if base.chars().count() != 1 {
+        return None;
+    }
+    (display_width(base) == 1 && display_width(cluster) == 2).then_some(base)
+}
+
 /// The display width of a **one-cell piece** of text, in `0..=2`.
 ///
 /// A terminal cell holds at most a double-width cluster, so this returns at most `2`.

--- a/src/text/tests.rs
+++ b/src/text/tests.rs
@@ -673,3 +673,41 @@ fn truncate_to_width_costs_a_wide_cluster_honestly() {
         WIDE_PLUS_SPACING_MARK
     );
 }
+
+// ---------------------------------------------------------------------------
+// Emoji presentation on a terminal that does not widen it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_variation_selector_is_dropped_from_a_narrow_base() {
+    // `unicode-width` gives U+2638 one column and U+2638 U+FE0F two, which is what
+    // the standard asks for and what several terminals do not do. Dropping the selector
+    // is what puts every measurement — ours, ratatui's and the terminal's — back on the
+    // same number, and it draws the same glyph on a terminal that ignored it anyway.
+    assert_eq!(narrow_emoji("a ☸️ b"), "a ☸ b");
+    assert_eq!(display_width(&narrow_emoji("a ☸️ b")), 5);
+}
+
+#[test]
+fn an_emoji_that_is_wide_on_its_own_is_left_alone() {
+    // No selector to drop, and nobody disagrees about these: every terminal measured
+    // gives them two columns.
+    for text in ["📄 Report", "🌾 Agrocheck", "👤 Fritz"] {
+        assert_eq!(narrow_emoji(text), text);
+    }
+}
+
+#[test]
+fn a_zwj_sequence_keeps_its_selectors() {
+    // Several emoji glued into one cluster. How wide a terminal draws that is its own
+    // disagreement, and taking a selector out of the middle would change which glyph
+    // is drawn rather than only how wide it is.
+    let family = "👨‍❤️‍👨";
+    assert_eq!(narrow_emoji(family), family);
+}
+
+#[test]
+fn text_with_nothing_to_drop_is_not_copied() {
+    let text = "plain prose with no emoji at all";
+    assert!(matches!(narrow_emoji(text), std::borrow::Cow::Borrowed(_)));
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,6 +22,7 @@
 //! | [`dump`] | `--render-once` output, ANSI or plain |
 //! | [`wide`] | Rendering over-wide blocks so they stay horizontally reachable |
 //! | `term` | Terminal lifecycle, signal safety and the event loop |
+//! | `probe` | Asking the terminal how wide it draws an emoji-presentation sequence |
 //!
 //! The split exists because design spec §13 requires application state to be testable
 //! without a terminal: [`app::App`] never touches one.
@@ -36,6 +37,7 @@ pub mod help;
 pub mod icons;
 pub mod open;
 pub mod popup;
+mod probe;
 pub mod select;
 pub mod stderr;
 mod term;
@@ -54,6 +56,15 @@ pub use app::{App, AppOptions, Focus, Overlay, PromptKind};
 /// Returns any I/O failure raised by the terminal.
 pub fn run(app: &mut App) -> std::io::Result<()> {
     term::run(app)
+}
+
+/// How many columns this terminal gives an emoji-presentation sequence, if it will say.
+///
+/// See [`probe`] for what is asked, when it is skipped, and why the answer is worth
+/// asking for. Exists here for the same reason [`terminal_width`] does: the binary need
+/// not depend on `crossterm` itself.
+pub fn emoji_columns() -> Option<u16> {
+    probe::emoji_columns()
 }
 
 /// Restores the terminal, for callers that need to bail out mid-flight.

--- a/src/tui/probe.rs
+++ b/src/tui/probe.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+//! Measuring what this terminal does with an emoji-presentation sequence.
+//!
+//! # Why measure at all
+//!
+//! `U+FE0F` asks for the emoji form of a character that also has a text form, and the
+//! standard makes the result two columns wide. Several terminals draw it in one and
+//! advance the cursor by one. Nothing downstream can paper over that: `unicode-width`
+//! says two, `ratatui` skips the second cell on that authority, and the terminal is
+//! then one column out for the rest of the run it was handed — which is what leaves
+//! stale glyphs across a scrolled screen.
+//!
+//! There is no capability string for this, so the only honest source is the terminal
+//! itself: draw the sequence, ask where the cursor ended up, and take the difference.
+//!
+//! # What is asked and when
+//!
+//! The probe writes at the start of a line and erases what it wrote, so nothing of it
+//! survives on screen. It is skipped altogether where the question cannot be put or the
+//! answer would mean nothing: no terminal on either standard input or standard output,
+//! no `TERM`, or a `TERM` that says up front there is nothing to ask (`dumb`, the Linux
+//! console). Anyone who would rather not be asked can settle it in the configuration
+//! file with `narrow_emoji`, and then this never runs.
+//!
+//! The reply is read here rather than through `crossterm::cursor::position`, which
+//! cannot be used for this: its loop treats a failed wait as nothing to report and goes
+//! round again, so a terminal that has been destroyed under it spins at 100 % of a core
+//! for ever — the very fault [`super::term`] exists to keep out of this program, and one
+//! the pty test catches. The wait here is a `poll` with a deadline that also watches for
+//! the hangup the kernel flags, and a terminal that stays silent costs a fifth of a
+//! second, once, at startup.
+
+use std::io::{self, IsTerminal, Write};
+#[cfg(unix)]
+use std::time::{Duration, Instant};
+
+/// The sequence the terminal is asked to draw.
+///
+/// A heart rather than the wheel that started this: both are a narrow base plus the
+/// selector, and this one is in every font that has any emoji at all — a probe the
+/// font cannot draw would measure the terminal's tofu instead of its intent.
+const PROBE: &str = "\u{2764}\u{FE0F}";
+
+/// How long a terminal is given to answer before the question is dropped.
+#[cfg(unix)]
+const PATIENCE: Duration = Duration::from_millis(200);
+
+/// How many columns this terminal gives [`PROBE`], or `None` if it would not say.
+///
+/// `Some(1)` is the disagreement this exists to find; `Some(2)` is the standard
+/// behaviour. Anything else — an unanswerable question, a terminal that stays silent,
+/// a reply that makes no sense — is `None`, and the caller is expected to carry on as
+/// though the terminal were the ordinary sort. This is deliberately lopsided in the
+/// same way [`crate::nerdfont`] is: a wrong "narrow" would strip selectors on a
+/// terminal that wanted them, so only a clear answer changes anything.
+pub fn emoji_columns() -> Option<u16> {
+    if !io::stdout().is_terminal() || !io::stdin().is_terminal() {
+        return None;
+    }
+    match std::env::var("TERM").ok()?.as_str() {
+        "" | "dumb" | "linux" => return None,
+        _ => {}
+    }
+    // Raw mode for the reading: the reply is not a line and nobody typed a newline
+    // after it, and echoing it would print it over the screen it was measured on.
+    crossterm::terminal::enable_raw_mode().ok()?;
+    let answer = measure();
+    let _ = crossterm::terminal::disable_raw_mode();
+    // Erase the whole line rather than the columns the probe is believed to occupy:
+    // what it occupies is the very thing in question. Unconditional, so a probe that
+    // was drawn and then not answered still leaves nothing behind.
+    let mut out = io::stdout();
+    let _ = write!(out, "\r\x1b[K");
+    let _ = out.flush();
+    // The report counts from one, and the probe started in the first column.
+    answer?.checked_sub(1)
+}
+
+/// Draws the probe from the start of the line and reads back the column it ended in.
+fn measure() -> Option<u16> {
+    let mut out = io::stdout();
+    // From the start of the line, so the reply *is* the width of the probe, with no
+    // arithmetic against a prompt that may itself contain anything.
+    write!(out, "\r{PROBE}\x1b[6n").ok()?;
+    out.flush().ok()?;
+    reply()
+}
+
+/// The column from the terminal's report, if one arrives in time.
+///
+/// The reply can be split across reads, and other input can arrive with it, so bytes are
+/// accumulated until they hold a report or the deadline passes. Anything else that came
+/// with it is dropped — a keystroke typed into the first fraction of a second of startup,
+/// which is the same cost every implementation of this question pays.
+#[cfg(unix)]
+fn reply() -> Option<u16> {
+    use rustix::event::{PollFd, PollFlags, poll};
+
+    let stdin = rustix::stdio::stdin();
+    let deadline = Instant::now() + PATIENCE;
+    let mut seen = Vec::with_capacity(32);
+    loop {
+        let left = deadline.saturating_duration_since(Instant::now());
+        if left.is_zero() {
+            return None;
+        }
+        let mut fds = [PollFd::new(&stdin, PollFlags::IN)];
+        let timeout = rustix::event::Timespec {
+            tv_sec: left.as_secs().try_into().ok()?,
+            tv_nsec: left.subsec_nanos().into(),
+        };
+        match poll(&mut fds, Some(&timeout)) {
+            // Nothing arrived within the deadline, or the terminal is gone: either way
+            // there is no answer, and neither is an error worth reporting.
+            Ok(0) => return None,
+            Ok(_) => {}
+            Err(rustix::io::Errno::INTR) => continue,
+            Err(_) => return None,
+        }
+        if fds[0]
+            .revents()
+            .intersects(PollFlags::HUP | PollFlags::ERR | PollFlags::NVAL)
+        {
+            return None;
+        }
+        let mut buf = [0u8; 32];
+        match rustix::io::read(stdin, &mut buf) {
+            Ok(0) | Err(_) => return None,
+            Ok(read) => seen.extend_from_slice(&buf[..read]),
+        }
+        if let Some(column) = column_of(&seen) {
+            return Some(column);
+        }
+        // A cap, so a terminal that streams something else for ever cannot grow this
+        // without bound. The report is short and arrives first.
+        if seen.len() > 256 {
+            return None;
+        }
+    }
+}
+
+/// No `poll` to lean on, so the question is not put at all.
+///
+/// Windows, where asking would mean waiting without a deadline — the one thing this
+/// module refuses to do. `narrow_emoji` in the configuration file settles it there.
+#[cfg(not(unix))]
+fn reply() -> Option<u16> {
+    None
+}
+
+/// The column reported by `ESC [ rows ; cols R`, if `bytes` holds such a report.
+///
+/// Scans for the last complete report rather than assuming the reply arrived alone: a
+/// terminal may answer something else first, and a keystroke may land in the same read.
+pub(super) fn column_of(bytes: &[u8]) -> Option<u16> {
+    let mut answer = None;
+    for start in 0..bytes.len().saturating_sub(1) {
+        if bytes[start] != 0x1b || bytes[start + 1] != b'[' {
+            continue;
+        }
+        let rest = &bytes[start + 2..];
+        let Some(end) = rest.iter().position(|&byte| byte == b'R') else {
+            continue;
+        };
+        let report = &rest[..end];
+        let Some((rows, columns)) = split_once(report, b';') else {
+            continue;
+        };
+        if let (Some(_), Some(column)) = (number(rows), number(columns)) {
+            answer = Some(column);
+        }
+    }
+    answer
+}
+
+/// `bytes` split around the first `at`, or `None` if it does not contain one.
+fn split_once(bytes: &[u8], at: u8) -> Option<(&[u8], &[u8])> {
+    let index = bytes.iter().position(|&byte| byte == at)?;
+    Some((&bytes[..index], &bytes[index + 1..]))
+}
+
+/// `bytes` as a decimal number, or `None` if it is not one that fits.
+fn number(bytes: &[u8]) -> Option<u16> {
+    if bytes.is_empty() || !bytes.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    std::str::from_utf8(bytes).ok()?.parse().ok()
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -7438,3 +7438,35 @@ fn a_popup_shows_the_source_of_math_that_will_not_draw() {
         "a formula that will not draw shows its source, not a hole: {text:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Reading the terminal's answer to `ESC [ 6 n` (`super::probe`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_cursor_report_is_read_as_a_column() {
+    assert_eq!(super::probe::column_of(b"\x1b[1;3R"), Some(3));
+    assert_eq!(super::probe::column_of(b"\x1b[24;80R"), Some(80));
+}
+
+#[test]
+fn a_report_is_found_among_whatever_else_arrived() {
+    // A keystroke can land in the same read as the reply, and a terminal is free to
+    // answer other things first.
+    assert_eq!(super::probe::column_of(b"q\x1b[1;3R"), Some(3));
+    assert_eq!(super::probe::column_of(b"\x1b[?1;2c\x1b[1;5R"), Some(5));
+}
+
+#[test]
+fn anything_that_is_not_a_report_is_no_answer() {
+    for bytes in [
+        &b""[..],
+        &b"\x1b["[..],
+        &b"\x1b[1;R"[..],
+        &b"\x1b[1;3"[..],
+        &b"hello"[..],
+        &b"\x1b[99999;99999R"[..],
+    ] {
+        assert_eq!(super::probe::column_of(bytes), None, "{bytes:?}");
+    }
+}


### PR DESCRIPTION
Scrolling a document that contains `☸️`, `❤️` or `⚠️` left stale characters strewn
across the screen, well beyond the line the glyph was on.

## Root cause

`U+FE0F` asks for the emoji form of a character that also has a text form, and the
standard makes the result two columns wide. Measured on the terminal that reported this:

| Sequence | that terminal | `unicode-width` |
|---|---|---|
| 📄 U+1F4C4 | 2 | 2 |
| 🌾 U+1F33E | 2 | 2 |
| ☸️ U+2638 U+FE0F | **1** | **2** |

Nothing downstream can absorb the disagreement: `unicode-width` says two, `ratatui`
skips the second cell on that authority, and the terminal is then one column out for
the rest of what it was handed. `ratatui` writes a contiguous run of changed cells
without repositioning the cursor, across row boundaries, so one wrong cell drags every
row after it in that run and leaves a character of the previous frame standing at the
end of each — which is what the report looked like.

Under tmux the same sequences measure two columns, so no fixed number is right for
everyone.

## What this does

Asks the terminal at startup: draw the sequence at the start of a line, read back the
cursor column, erase the line. A clear answer of one column drops the selector for the
rest of the session — the same glyph on such a terminal, and every measurement back on
one number. Silence, nonsense and the standard answer all leave the document exactly as
it was, the lopsided rule `nerdfont` already follows.

The question is skipped where it cannot be put or would mean nothing: no terminal on
both standard input and standard output, `TERM` unset, `dumb` or `linux`, and on
Windows, where there is no `poll` to bound the wait with. `narrow_emoji` in the
configuration file and `--narrow-emoji` / `--wide-emoji` settle it without measuring; a
flag is saved by `S`, a measurement never is.

Stripping happens on the source before the parser, so wrapping, table columns, the
canvas and the diff all measure text they agree about.

## Why not `crossterm::cursor::position`

It was the first implementation, and the pty test failed on it: its read loop treats a
failed wait as nothing to report and goes round again, so a terminal destroyed under it
spins at 100 % of a core — the exact fault `term` was written to keep out of this
program. The reply is now read here, waiting on a `poll` with a 200 ms deadline that
also gives up on the hangup the kernel flags.

## API break

`Config` gained `narrow_emoji: Option<bool>`, tri-state like `icons` for the same
reason. Recorded in `CHANGES.md`.

## Testing

10 new tests, each watched fail first: the selector dropped from a narrow base and kept
in a ZWJ sequence, an already-wide emoji left alone, borrowed rather than copied when
there is nothing to drop; the cursor-report parser against a clean reply, a reply mixed
with other input, and six malformed ones; the resolution order, including that a stated
answer never lets the terminal be asked at all.

`cargo test` (34 binaries, the pty hangup test among them), `cargo clippy --all-targets`
and `cargo fmt --check` are clean. Checked end to end as well: `--render-once` keeps the
selector by default and drops it under `--narrow-emoji`, with `📄` untouched either way.
